### PR TITLE
Initial version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,11 @@ import PackageDescription
 
 let package = Package(
     name: "SnapAuth",
+    platforms: [
+        .macOS(.v12),
+//        .macCatalyst(.v13),
+        .iOS(.v12),
+    ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [
         .macOS(.v12),
 //        .macCatalyst(.v13),
-        .iOS(.v12),
+        .iOS(.v15),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -9,6 +9,8 @@ let package = Package(
         .macOS(.v12),
 //        .macCatalyst(.v13),
         .iOS(.v15),
+        .tvOS(.v16),
+        .visionOS(.v1),
     ],
     products: [
         // Products define the executables and libraries a package produces, making them visible to other packages.

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,10 @@ let package = Package(
         // Targets are the basic building blocks of a package, defining a module or a test suite.
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
-            name: "SnapAuth"),
+            name: "SnapAuth",
+            swiftSettings: [
+                .define("HARDWARE_KEY_SUPPORT", .when(platforms: [.iOS, .macOS]))
+            ]),
         .testTarget(
             name: "SnapAuthTests",
             dependencies: ["SnapAuth"]),

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Platform | Passkeys | Hardware Keys
 iOS | ✅ 15.0+ | ✅[^usb-hardware-varies] 15.0+
 iPadOS | ✅ 15.0+ | ✅[^usb-hardware-varies] 15.0+
 macOS | ✅ 12.0+ | ✅ 12.0+
+macOS (Catalyst) | ⚠️[^platform-untested] | ⚠️[^platform-untested]
 visionOS | ✅ 1.0+ | ❌[^no-usb]
 tvOS | ⚠️[^platform-untested] 16.0+ | ❌[^no-usb]
 watchOS | ❌[^no-watch] | ❌[^no-watch]
@@ -40,7 +41,7 @@ Starting with a testing or staging server is often an easier place to start.
 
 > [!TIP]
 > You may have already done this if your existing app supports password autofill.
-> 
+>
 > Still, fully review this section!
 
 More info:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,107 @@
+# SnapAuth Swift SDK
+
+This is the official Swift SDK for [SnapAuth](https://www.snapauth.app).
+
+## Platform Support
+
+This SDK supports all major Apple platforms that support passkeys:
+
+Platform | Passkeys | Hardware Keys
+--- | --- |---
+iOS | Yes | Yes
+iPadOS | Yes | Yes
+macOS | Yes | Yes
+visionOS | Yes | No[^no-platform]
+tvOS | ⚠️[^platform-unested] | No[^no-platform]
+watchOS | No[^no-platform] | No[^no-platform]
+
+## Setup
+
+If you haven't already registered for SnapAuth, do so: https://www.snapauth.app/register
+
+Use it to get your `publishable key` from the Dashboard.
+
+### Add the SDK
+
+XCode > File > Add Package Dependencies...
+
+In the add package dialog, search for our SDK:
+
+`https://github.com/snapauthapp/sdk-swift`
+
+Select a Dependency Rule and add it to your development target.
+We recommend "Dependency Rule: Up to Next Major Version".
+
+### Import the SDK
+
+In any files that need to integrate with SnapAuth, be sure to import it:
+
+```swift
+import SnapAuth
+```
+
+## Usage
+
+SnapAuth will get you up and running with passkeys in a snap!
+
+### Implement `SnapAuthDelegate`
+
+If using SwiftUI, this can be done directly on a `View`.
+You may also do this in a separate class or struct.
+
+This will be called by our SDK when a user either authenticates or cancels the request.
+
+Example:
+```swift
+import SnapAuth
+
+func snapAuth(didFinishAuthentication result: Result<SnapAuthAuth, AuthenticationError>) async {
+    guard case .success(let auth) = result else {
+        // User did not or could not authenticate. Update your UI accordingly
+        return
+    }
+    // Send `auth.token` to your backend for server-side verification. Use it to
+    // determine the authenticating user, and send back an appropriate response
+    // to the client code.
+}
+```
+
+Registration is substantially the same.
+
+### Call the API
+
+This will typically be done in a Button's action.
+Here's a very simple sign-in View in SwiftUI:
+
+```swift
+import SnapAuth
+import SwiftUI
+
+struct SignInView: View {
+  let snapAuth = SnapAuth(publishableKey: "pubkey_yourkey")
+
+  @State var username: String = ""
+
+  var body: some View {
+    VStack {
+      TextField("Username", text: $username)
+      Button("Sign In", systemImage: "person.badge.key") {
+        signIn()
+      }
+    }
+  }
+
+  func signIn() {
+    Task {
+      snapAuth.delegate = self
+      await snapAuth.startAuth(.handle(username), anchor: ASPresentationAnchor())
+    }
+  }
+}
+extension SignInView: SnapAuthDelegate {
+  // delegate methods described above
+}
+```
+
+[^no-platform]: Unsupported by Apple (no USB port!)
+[^platform-untested]: Untested, but will probably work

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ This file must be served at `https://yourdomain.tld/.well-known/apple-app-site-a
 
 `curl https://yourdomain.tld/.well-known/apple-app-site-association` to test it.
 
+> [!CAUTION]
+> If you already have a Domain Association file, be sure only to append or merge this change.
+> Do not replace other content in the file, which could lead to breaking other app functionality!
+
 #### Your App ID
 
 Your App ID can be obtained from the Apple developer portal(s):

--- a/README.md
+++ b/README.md
@@ -70,15 +70,13 @@ This should match the `RP ID` from the SnapAuth dashboard.
 
 ### Publish the domain association file
 
-Get your App ID from the Apple Developer portal.
-
 Create the assoication file (or, if you already have one for other capabilities, add this section):
 
 ```json
 {
   "webcredentials": {
     "apps": [
-      "your app id"
+      "your App ID"
     ]
   }
 }
@@ -87,6 +85,22 @@ Create the assoication file (or, if you already have one for other capabilities,
 This file must be served at `https://yourdomain.tld/.well-known/apple-app-site-association`.
 
 `curl https://yourdomain.tld/.well-known/apple-app-site-association` to test it.
+
+#### Your App ID
+
+Your App ID can be obtained from the Apple developer portal(s):
+
+https://developer.apple.com/account/resources/identifiers/list > Select your app
+
+or
+
+https://developer.apple.com/account#MembershipDetailsCard > Look for Team ID, and
+
+XCode > Your app (the root-level object in Navigator) > Targets > (pick one) > General, look for Bundle Identifier
+
+The App ID is the combination of the Team ID (typically 10 characters) and the Bundle ID (typically configured in-app, frequently in reverse-DNS format): `TeamID.BundleID`
+
+This will result in something like `A5B4C3D2E1.tld.yourdomain.YourAppName`
 
 #### Optional: enable SWC Developer Mode
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ More info:
 
 - https://developer.apple.com/documentation/xcode/supporting-associated-domains
 - https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains
--
 
 In XCode, select your root-level project in the Navigator.
 
@@ -80,7 +79,7 @@ Create the assoication file (or, if you already have one for other capabilities,
 
 This file must be served at `https://yourdomain.tld/.well-known/apple-app-site-association`.
 
-`curl https://yourdomain.tld/.well-known/apple-app-site-association`
+`curl https://yourdomain.tld/.well-known/apple-app-site-association` to test it.
 
 #### Optional: enable SWC Developer Mode
 

--- a/README.md
+++ b/README.md
@@ -32,16 +32,9 @@ watchOS | ❌[^no-watch] | ❌[^no-watch]
 
 If you haven't already registered for SnapAuth, do so: https://www.snapauth.app/register
 
-Unlike for web integrations, `localhost` generally does not work on Apple native apps.
-
-You should immediately create a non-local environment to test with, if you haven't already done so.
-Starting with a testing or staging server is a good place to start.
-
-<!--
-The `RP ID` from the dashbard _must_ exactly match the Associated Domains configuration below
-
-(This needs to be verified - the AD is what'll get checked for the file, but a subdomain match on the RP ID might be ok)
--->
+Unlike for web integrations, `localhost` generally does not work nicely on Apple native apps.
+It should be possbile, but unlike on web must still use `https` which local environments don't always support well.
+Starting with a testing or staging server is often an easier place to start.
 
 ### Add the Associated Domains capability
 
@@ -61,14 +54,19 @@ Select your Target, and navigate to the Signing & Capabilities tab.
 
 Click `+ Capability` and select `Associated Domains`
 
-> [!NOTE]
+> [!WARNING]
 > This capability is restricted on free Apple Developer accounts.
 > Unfortunately, this means you must have a current, paid account to proceed.
+
+<!-- Also, personal accounts might not work? -->
 
 In the new Associated Domains section, click `+` and add your domain(s):
 
 `webcredentials:yourdomain.tld`
 
+This should match the `RP ID` from the SnapAuth dashboard.
+
+<!-- Must match exactly? Registrable domain match? -->
 
 ### Publish the domain association file
 
@@ -122,6 +120,8 @@ In the add package dialog, search for our SDK:
 
 Select a Dependency Rule and add it to your development target.
 We recommend "Dependency Rule: Up to Next Major Version".
+
+We follow Semantic Versioning with all of our SDKs, so this should always be a safe option.
 
 ### Import the SDK
 
@@ -192,10 +192,19 @@ extension SignInView: SnapAuthDelegate {
 }
 ```
 
+## Known issues
+
+In our testing, the sign in dialog in tvOS doesn't open, at least in the simulator.
+
+Even with the Apple-documented configuration, the AutoFill API does not reliably provide passkey suggestions.
+
 ## Useful resources
 
- - https://developer.apple.com/videos/play/wwdc2021/10106/
- - https://developer.apple.com/videos/play/wwdc2022/10092/
+ - [WWDC21: Move beyond passwords](https://developer.apple.com/videos/play/wwdc2021/10106/)
+ - [WWDC22: Meet passkeys](https://developer.apple.com/videos/play/wwdc2022/10092/)
+ - [Supporting associated domains](https://developer.apple.com/documentation/xcode/supporting-associated-domains)
+ - [Associated domains entitlement](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_developer_associated-domains)
+ - https://forums.developer.apple.com/forums/thread/743890
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This SDK supports all major Apple platforms that support passkeys:
 
 Platform | Passkeys | Hardware Keys
 --- | --- |---
-iOS | Yes | Yes
-iPadOS | Yes | Yes
-macOS | Yes | Yes
-visionOS | Yes | No[^no-platform]
-tvOS | ⚠️[^platform-unested] | No[^no-platform]
-watchOS | No[^no-platform] | No[^no-platform]
+iOS | ✅ | ✅
+iPadOS | ✅ | ✅
+macOS | ✅ | ✅
+visionOS | ✅ | ❌[^no-platform]
+tvOS | ⚠️[^platform-untested] | ❌[^no-platform]
+watchOS | ❌[^no-platform] | ❌[^no-platform]
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -4,18 +4,18 @@ This is the official Swift SDK for [SnapAuth](https://www.snapauth.app).
 
 ## Platform Support
 
-This SDK supports all major Apple platforms that support passkeys:
+This SDK supports all major Apple platforms that support passkeys and hardware authenticators:
 
 Platform | Passkeys | Hardware Keys
---- | --- |---
-iOS | ✅ | ✅
-iPadOS | ✅ | ✅
-macOS | ✅ | ✅
-visionOS | ✅ | ❌[^no-platform]
-tvOS | ⚠️[^platform-untested] | ❌[^no-platform]
-watchOS | ❌[^no-platform] | ❌[^no-platform]
+--- | --- | ---
+iOS | ✅ 15.0+ | ✅[^usb-hardware-varies] 15.0+
+iPadOS | ✅ 15.0+ | ✅[^usb-hardware-varies] 15.0+
+macOS | ✅ 12.0+ | ✅ 12.0+
+visionOS | ✅ 1.0+ | ❌[^no-usb]
+tvOS | ⚠️[^platform-untested] 16.0+ | ❌[^no-usb]
+watchOS | ❌[^no-watch] | ❌[^no-watch]
 
-## Setup
+## Apple-specific setup
 
 > [!IMPORTANT]
 > All native apps require special domain confirmation to use.
@@ -99,7 +99,9 @@ sudo swcutil developer-mode -e 1
 
 You still **must** publish the association file; this only bypasses the cache.
 
+## Usage
 
+SnapAuth will get you up and running with passkeys in a snap!
 
 ### Add the SDK
 
@@ -120,10 +122,6 @@ In any files that need to integrate with SnapAuth, be sure to import it:
 import SnapAuth
 ```
 
-## Usage
-
-SnapAuth will get you up and running with passkeys in a snap!
-
 ### Implement `SnapAuthDelegate`
 
 If using SwiftUI, this can be done directly on a `View`.
@@ -135,9 +133,9 @@ Example:
 ```swift
 import SnapAuth
 
-func snapAuth(didFinishAuthentication result: Result<SnapAuthAuth, AuthenticationError>) async {
+func snapAuth(didFinishAuthentication result: SnapAuthTokenInfo) async {
     guard case .success(let auth) = result else {
-        // User did not or could not authenticate. Update your UI accordingly
+        // User did not or could not authenticate.
         return
     }
     // Send `auth.token` to your backend for server-side verification. Use it to
@@ -185,5 +183,7 @@ extension SignInView: SnapAuthDelegate {
 }
 ```
 
-[^no-platform]: Unsupported by Apple (no USB port!)
+[^no-watch]: Passkeys are not supported on Apple Watch
+[^no-usb]: Unsupported by Apple (no USB port!)
 [^platform-untested]: Untested, but will probably work
+[^usb-hardware-varies]: Supported at the platform level, but compatibility varies by device. As a general rule, if it physically fits, it should work.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # SnapAuth Swift SDK
 
-This is the official Swift SDK for [SnapAuth](https://www.snapauth.app).
+This is the official Swift SDK for [SnapAuth](https://www.snapauth.app?utm_source=GitHub&utm_campaign=sdk&utm_content=sdk-swift).
+
+🚧 This SDK is in beta! 🚧
+
+![GitHub License](https://img.shields.io/github/license/snapauthapp/sdk-typescript)
+
+- [SnapAuth Homepage](https://www.snapauth.app?utm_source=GitHub&utm_campaign=sdk&utm_content=sdk-swift)
+- [Docs](https://docs.snapauth.app)
+- [Dashboard](https://dashboard.snapauth.app)
+- [Github](https://github.com/snapauthapp/sdk-swift)
 
 ## Platform Support
 
@@ -182,6 +191,15 @@ extension SignInView: SnapAuthDelegate {
   // delegate methods described above
 }
 ```
+
+## Useful resources
+
+ - https://developer.apple.com/videos/play/wwdc2021/10106/
+ - https://developer.apple.com/videos/play/wwdc2022/10092/
+
+## License
+
+BSD-3-Clause
 
 [^no-watch]: Passkeys are not supported on Apple Watch
 [^no-usb]: Unsupported by Apple (no USB port!)

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -8,7 +8,7 @@ struct SAWrappedResponse<T>: Decodable where T: Decodable {
 }
 
 struct SACreateRegisterOptionsRequest: Encodable {
-    let user: SAUser?
+    let user: AuthenticatingUser?
 }
 struct SACreateRegisterOptionsResponse: Decodable {
     let publicKey: PublicKeyOptions
@@ -105,7 +105,7 @@ struct SACreateAuthOptionsResponse: Decodable {
 struct SAProcessAuthRequest: Encodable {
     // user ~ id/handle (skip for now since this is passkey only flow...ish)
     let credential: SACredential
-    let user: SAUser?
+    let user: AuthenticatingUser?
     struct SACredential: Codable {
         let type: String = "public-key"
         let rawId: Base64URL

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -10,6 +10,80 @@ struct SAWrappedResponse<T>: Decodable where T: Decodable {
     let result: T
 }
 
+struct SACreateRegisterOptionsRequest: Encodable {
+    let user: SAUser?
+}
+struct SACreateRegisterOptionsResponse: Decodable {
+    let publicKey: PublicKeyOptions
+
+    struct PublicKeyOptions: Decodable {
+        let rp: RPInfo
+        let user: UserInfo
+        let challenge: Base64URL
+        // let pubKeyCredParams: ['type' => 'public-key', 'alg' => Int][]
+        // timeout: Int
+        let attestation: Attestation
+        // authenticatorSelection is a mess
+
+        struct RPInfo: Decodable {
+            let id: String
+            let name: String
+        }
+        struct UserInfo: Decodable {
+            let id: Base64URL
+        }
+    }
+}
+
+struct SAProcessRegisterRequest: Encodable {
+    let credential: RegCredential
+
+    struct RegCredential: Encodable {
+        let type: String = "public-key"
+        let rawId: Base64URL
+        let response: RegResponse
+        // authenticatorAttachment
+        // clientExtensionResults
+        struct RegResponse: Encodable {
+            let clientDataJSON: Base64URL
+            let attestationObject: Base64URL
+            let transports: [Transport]
+        }
+    }
+}
+
+
+enum Attestation: String, Decodable {
+    case none
+    case indirect
+    case direct
+    case enterprise
+}
+
+
+enum Transport: String, Encodable {
+    case ble
+    case smartCard = "smart-card"
+    case hybrid
+    case `internal`
+    case nfc
+    case usb
+
+    /*
+    private typealias ASTransport = ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor.Transport
+
+    init(from asFormat: ASTransport) {
+        switch asFormat {
+        case ASTransport.bluetooth:
+            self = .ble
+        case ASTransport.nfc:
+            self = .nfc
+        case ASTransport.usb:
+            self = .usb
+        }
+    }
+     */
+}
 
 
 

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+// just decodable? Also, build this on top of Result<S,E>?
+/**
+ Wrapper that matches the API wire format
+
+ Network calls (non-broken) will return the result and 0 or more errors on response, or null and one or more errors on error
+
+ */
+struct SAWrappedResponse<T>: Decodable where T: Decodable {
+    let result: T
+}
+
+
+
+
+struct SACreateAuthOptionsResponse: Decodable {
+    let publicKey: PublicKeyOptions
+    // mediation
+
+    struct PublicKeyOptions: Decodable {
+
+        struct AllowCredential: Decodable {
+            let type: String // == "public-key"
+            let id: Base64URL
+            // transports?
+        }
+
+        let rpId: String
+        let challenge: Base64URL
+        let allowCredentials: [AllowCredential]?
+    }
+}
+
+struct SAProcessAuthRequest: Encodable {
+    // user ~ id/handle (skip for now since this is passkey only flow...ish)
+    let credential: SACredential
+    let user: SAUser?
+    struct SACredential: Codable {
+        let type: String = "public-key"
+        let rawId: Base64URL
+        let response: SACredential.Response
+        struct Response: Codable {
+            let authenticatorData: Base64URL
+            let clientDataJSON: Base64URL
+            let signature: Base64URL
+            let userHandle: Base64URL?
+        }
+    }
+
+}
+
+struct SAProcessAuthResponse {
+    let token: String
+    let expiresAt: Date
+}
+extension SAProcessAuthResponse: Decodable {
+    // Unixtime needs custom decoding
+    enum CodingKeys: CodingKey {
+        case token
+        case expiresAt
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.token = try container.decode(String.self, forKey: .token)
+        let timestamp = try container.decode(Int.self, forKey: .expiresAt)
+        expiresAt = Date(timeIntervalSince1970: TimeInterval(timestamp))
+//        self.expiresAt = try container.decode(Date.self, forKey: .expiresAt)
+    }
+}

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -1,11 +1,8 @@
 import Foundation
 
-/**
- Wrapper that matches the API wire format
-
- Network calls (non-broken) will return the result and 0 or more errors on response, or null and one or more errors on error
-
- */
+/// Wrapper that matches the API wire format
+///
+/// Network calls (non-broken) will return the result and 0 or more errors on response, or null and one or more errors on error
 struct SAWrappedResponse<T>: Decodable where T: Decodable {
     let result: T
 }

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -3,8 +3,15 @@ import Foundation
 /// Wrapper that matches the API wire format
 ///
 /// Network calls (non-broken) will return the result and 0 or more errors on response, or null and one or more errors on error
+// FIXME: this is not strictly correct
 struct SAWrappedResponse<T>: Decodable where T: Decodable {
-    let result: T
+    let result: T?
+    let errors: [SAApiError]?
+
+    struct SAApiError: Decodable {
+        let code: String
+        let message: String
+    }
 }
 
 struct SACreateRegisterOptionsRequest: Encodable {

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -49,22 +49,7 @@ struct SAProcessAuthRequest: Encodable {
 
 }
 
-struct SAProcessAuthResponse {
+struct SAProcessAuthResponse: Decodable {
     let token: String
     let expiresAt: Date
-}
-extension SAProcessAuthResponse: Decodable {
-    // Unixtime needs custom decoding
-    enum CodingKeys: CodingKey {
-        case token
-        case expiresAt
-    }
-
-    public init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.token = try container.decode(String.self, forKey: .token)
-        let timestamp = try container.decode(Int.self, forKey: .expiresAt)
-        expiresAt = Date(timeIntervalSince1970: TimeInterval(timestamp))
-//        self.expiresAt = try container.decode(Date.self, forKey: .expiresAt)
-    }
 }

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -1,6 +1,5 @@
 import Foundation
 
-// just decodable? Also, build this on top of Result<S,E>?
 /**
  Wrapper that matches the API wire format
 

--- a/Sources/SnapAuth/ApiClient.swift
+++ b/Sources/SnapAuth/ApiClient.swift
@@ -45,10 +45,13 @@ struct SnapAuthClient {
         let jsonString = String(data: data, encoding: .utf8)
         logger?.debug("<-- \(jsonString ?? "not a string")")
 
-//        Skip custom codable?
-//        let jd = JSONDecoder()
-//        jd.dateDecodingStrategy = .secondsSince1970
-        guard let parsed = try? JSONDecoder().decode(SAWrappedResponse<T>.self, from: data) else {
+        // This allows skipping custom decodable implementations
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .secondsSince1970
+        guard let parsed = try? decoder.decode(
+            SAWrappedResponse<T>.self,
+            from: data)
+        else {
             logger?.error("nope")
             /// TODO: return some sort of failure SAResponse
             return nil

--- a/Sources/SnapAuth/ApiClient.swift
+++ b/Sources/SnapAuth/ApiClient.swift
@@ -52,8 +52,8 @@ struct SnapAuthClient {
             SAWrappedResponse<T>.self,
             from: data)
         else {
-            logger?.error("nope")
-            /// TODO: return some sort of failure SAResponse
+            logger?.error("Decoding request failed")
+            // TODO: return some sort of failure SAResponse
             return nil
         }
 

--- a/Sources/SnapAuth/ApiClient.swift
+++ b/Sources/SnapAuth/ApiClient.swift
@@ -1,0 +1,60 @@
+//
+//  File.swift
+//  
+//
+//  Created by Eric Stern on 5/15/24.
+//
+
+import Foundation
+import os
+
+/**
+ Internal API call wrapper
+ */
+struct SnapAuthClient {
+    private let urlBase: URL
+    private let publishableKey: String
+    private let logger: Logger?
+
+    init(urlBase: URL, publishableKey: String, logger: Logger?) {
+        self.urlBase = urlBase
+        self.publishableKey = publishableKey
+        self.logger = logger
+    }
+
+    /// Auth header generation
+    var basic: String {
+        return "Basic " + Data("\(publishableKey):".utf8).base64EncodedString()
+    }
+
+    func makeRequest<T>(
+        path: String,
+        body: Encodable,
+        type: T.Type
+    ) async -> SAWrappedResponse<T>? {
+        let url = urlBase.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue(basic, forHTTPHeaderField: "Authorization")
+        let json = try! JSONEncoder().encode(body)
+        request.httpBody = json
+        logger?.debug("--> \(String(decoding: json, as: UTF8.self))")
+
+        let (data, response) = try! await URLSession.shared.data(for: request)
+        let jsonString = String(data: data, encoding: .utf8)
+        logger?.debug("<-- \(jsonString ?? "not a string")")
+
+//        Skip custom codable?
+//        let jd = JSONDecoder()
+//        jd.dateDecodingStrategy = .secondsSince1970
+        guard let parsed = try? JSONDecoder().decode(SAWrappedResponse<T>.self, from: data) else {
+            logger?.error("nope")
+            /// TODO: return some sort of failure SAResponse
+            return nil
+        }
+
+        return parsed
+    }
+
+}

--- a/Sources/SnapAuth/ApiClient.swift
+++ b/Sources/SnapAuth/ApiClient.swift
@@ -1,16 +1,7 @@
-//
-//  File.swift
-//  
-//
-//  Created by Eric Stern on 5/15/24.
-//
-
 import Foundation
 import os
 
-/**
- Internal API call wrapper
- */
+/// Internal API call wrapper
 struct SnapAuthClient {
     private let urlBase: URL
     private let publishableKey: String

--- a/Sources/SnapAuth/Base64URL.swift
+++ b/Sources/SnapAuth/Base64URL.swift
@@ -10,7 +10,7 @@ import Foundation
 struct Base64URL: Codable {
     private var base64URLString: String
     
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         base64URLString = try container.decode(String.self)
     }
@@ -23,7 +23,7 @@ struct Base64URL: Codable {
             .replacingOccurrences(of: "=", with: "") // FIXME: this should be explicitly rtrim
     }
     
-    func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(base64URLString)
     }
@@ -47,7 +47,7 @@ struct Base64URL: Codable {
 //     }
 }
 extension Base64URL: CustomStringConvertible {
-    var description: String {
+     var description: String {
         return base64URLString
     }
 }

--- a/Sources/SnapAuth/Base64URL.swift
+++ b/Sources/SnapAuth/Base64URL.swift
@@ -5,7 +5,7 @@ struct Base64URL: Codable {
     private var base64URLString: String
 
     /// Allows for direct decoding of Base64URL values from e.g. JSON
-    public init(from decoder: Decoder) throws {
+    init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         base64URLString = try container.decode(String.self)
     }
@@ -19,7 +19,7 @@ struct Base64URL: Codable {
     }
 
     /// Allows direct encoding into a Base64URL string to e.g. JSON
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(base64URLString)
     }

--- a/Sources/SnapAuth/Base64URL.swift
+++ b/Sources/SnapAuth/Base64URL.swift
@@ -4,6 +4,7 @@ import Foundation
 struct Base64URL: Codable {
     private var base64URLString: String
 
+    /// Allows for direct decoding of Base64URL values from e.g. JSON
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         base64URLString = try container.decode(String.self)
@@ -17,10 +18,12 @@ struct Base64URL: Codable {
             .replacingOccurrences(of: "=", with: "") // FIXME: this should be explicitly rtrim
     }
 
+    /// Allows direct encoding into a Base64URL string to e.g. JSON
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(base64URLString)
     }
+
     func toData() -> Data? {
         var rawBase64 = base64URLString
             .replacingOccurrences(of: "-", with: "+")
@@ -29,7 +32,6 @@ struct Base64URL: Codable {
         if (remainder > 0) {
             rawBase64.append(String(repeating: "=", count: 4 - remainder))
         }
-        // does this need to be padded?
         if let data = Data(base64Encoded: rawBase64) {
             return data
         }

--- a/Sources/SnapAuth/Base64URL.swift
+++ b/Sources/SnapAuth/Base64URL.swift
@@ -1,20 +1,14 @@
-//
-//  Base64URL.swift
-//  PassKeyExample
-//
-//  Created by Eric Stern on 3/13/24.
-//
-
 import Foundation
 
+/// Converts in and out of Base64URL formats
 struct Base64URL: Codable {
     private var base64URLString: String
-    
+
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         base64URLString = try container.decode(String.self)
     }
-    
+
     /// Reads in Data representing a base64 (not base64url) string
     init(from data: Data) {
         base64URLString = data.base64EncodedString()
@@ -22,7 +16,7 @@ struct Base64URL: Codable {
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "") // FIXME: this should be explicitly rtrim
     }
-    
+
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(base64URLString)
@@ -40,14 +34,11 @@ struct Base64URL: Codable {
             return data
         }
         return nil
-     }
-     
-//     init(base64String: String) {
-//         self.base64String = base64String
-//     }
+    }
 }
+
 extension Base64URL: CustomStringConvertible {
-     var description: String {
+    var description: String {
         return base64URLString
     }
 }

--- a/Sources/SnapAuth/Base64URL.swift
+++ b/Sources/SnapAuth/Base64URL.swift
@@ -1,0 +1,53 @@
+//
+//  Base64URL.swift
+//  PassKeyExample
+//
+//  Created by Eric Stern on 3/13/24.
+//
+
+import Foundation
+
+struct Base64URL: Codable {
+    private var base64URLString: String
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        base64URLString = try container.decode(String.self)
+    }
+    
+    /// Reads in Data representing a base64 (not base64url) string
+    init(from data: Data) {
+        base64URLString = data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "") // FIXME: this should be explicitly rtrim
+    }
+    
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(base64URLString)
+    }
+    func toData() -> Data? {
+        var rawBase64 = base64URLString
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let remainder = rawBase64.count % 4
+        if (remainder > 0) {
+            rawBase64.append(String(repeating: "=", count: 4 - remainder))
+        }
+        // does this need to be padded?
+        if let data = Data(base64Encoded: rawBase64) {
+            return data
+        }
+        return nil
+     }
+     
+//     init(base64String: String) {
+//         self.base64String = base64String
+//     }
+}
+extension Base64URL: CustomStringConvertible {
+    var description: String {
+        return base64URLString
+    }
+}

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -1,0 +1,14 @@
+//
+//  File.swift
+//  
+//
+//  Created by Eric Stern on 5/15/24.
+//
+
+//import Foundation
+
+public enum AuthenticationError: Error {
+    case canceled
+    case networkDisrupted
+    // ...
+}

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -1,12 +1,4 @@
-//
-//  File.swift
-//  
-//
-//  Created by Eric Stern on 5/15/24.
-//
-
-//import Foundation
-
+// FIXME: Go through and ensure errors are complete and accurate.
 public enum AuthenticationError: Error {
     /// The user canceled
     case canceled
@@ -14,5 +6,4 @@ public enum AuthenticationError: Error {
     case networkDisrupted
 
     case asAuthorizationError
-    // ...
 }

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -8,7 +8,11 @@
 //import Foundation
 
 public enum AuthenticationError: Error {
+    /// The user canceled
     case canceled
+    /// There was a network interruption
     case networkDisrupted
+
+    case asAuthorizationError
     // ...
 }

--- a/Sources/SnapAuth/PresentationAnchor.swift
+++ b/Sources/SnapAuth/PresentationAnchor.swift
@@ -13,3 +13,7 @@ let defaultPresentationAnchor: ASPresentationAnchor = NSApplication.shared.mainW
 #else
 let defaultPresentationAnchor: ASPresentationAnchor = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController?.view.window ?? ASPresentationAnchor()
 #endif
+
+extension ASPresentationAnchor {
+    static let `default` = defaultPresentationAnchor
+}

--- a/Sources/SnapAuth/PresentationAnchor.swift
+++ b/Sources/SnapAuth/PresentationAnchor.swift
@@ -1,0 +1,15 @@
+//
+//  File.swift
+//  
+//
+//  Created by Eric Stern on 5/17/24.
+//
+
+import AuthenticationServices
+
+#if os(macOS)
+// TODO: this will probably crash if it tries to start with no window open (but also how could it?)
+let defaultPresentationAnchor: ASPresentationAnchor = NSApplication.shared.mainWindow!
+#else
+let defaultPresentationAnchor: ASPresentationAnchor = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController?.view.window ?? ASPresentationAnchor()
+#endif

--- a/Sources/SnapAuth/PresentationAnchor.swift
+++ b/Sources/SnapAuth/PresentationAnchor.swift
@@ -1,19 +1,14 @@
-//
-//  File.swift
-//  
-//
-//  Created by Eric Stern on 5/17/24.
-//
-
 import AuthenticationServices
 
 #if os(macOS)
-// TODO: this will probably crash if it tries to start with no window open (but also how could it?)
-let defaultPresentationAnchor: ASPresentationAnchor = NSApplication.shared.mainWindow!
+// FIXME: Figure out better fallback mechanisms here.
+// This will cause a new window to open _and remain open_
+fileprivate let defaultPresentationAnchor: ASPresentationAnchor = NSApplication.shared.mainWindow ?? ASPresentationAnchor()
 #else
-let defaultPresentationAnchor: ASPresentationAnchor = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController?.view.window ?? ASPresentationAnchor()
+fileprivate let defaultPresentationAnchor: ASPresentationAnchor = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController?.view.window ?? ASPresentationAnchor()
 #endif
 
 extension ASPresentationAnchor {
+    /// A platform-specific anchor, intended to be used by ASAuthorizationController
     static let `default` = defaultPresentationAnchor
 }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -1,0 +1,181 @@
+import AuthenticationServices
+
+// MARK: - ASAuthorizationControllerDelegate
+@available(macOS 12.0, iOS 15.0, visionOS 1.0, tvOS 16.0, *)
+extension SnapAuth: ASAuthorizationControllerDelegate {
+
+    public func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithError error: Error
+    ) {
+//        if case ASAuthorizationError.canceled = error {
+//        }
+        // TODO: don't bubble this up if it's from an autofill request
+        if let asError = error as? ASAuthorizationError {
+//            asError.code == .canceled
+
+
+            logger.error("ASACD \(asError.errorCode)")
+            // 1001 = no credentials available
+//        case unknown = 1000
+//        case canceled = 1001
+//        case invalidResponse = 1002
+//        case notHandled = 1003
+//        case failed = 1004
+//        case notInteractive = 1005
+        }
+        logger.error("ASACD fail: \(error)")
+        // (lldb) po error
+        // Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app" UserInfo={NSLocalizedFailureReason=Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app}
+        // (lldb) po error.localizedDescription
+        // "The operation couldn’t be completed. Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app"
+
+        // The start call can SILENTLY produce this error which never makes it into this handler
+        // ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
+
+        Task {
+            // Failure reason, etc, etc
+//            await delegate?.snapAuth(didAuthenticate: .failure)
+            // TODO: This needs to be aware of current flow (MAJOR)
+            await delegate?.snapAuth(didFinishAuthentication: .failure(.asAuthorizationError))
+        }
+    }
+
+    public func authorizationController(
+        controller: ASAuthorizationController,
+        didCompleteWithAuthorization authorization: ASAuthorization
+    ) {
+        if delegate == nil {
+            logger.error("No SnapAuth delegate set")
+            return
+        }
+        logger.debug("ASACD did complete")
+
+
+        switch authorization.credential {
+        case is ASAuthorizationPlatformPublicKeyCredentialAssertion:
+            logger.debug("switch passkey assn")
+            handleAssertion(authorization.credential as! ASAuthorizationPlatformPublicKeyCredentialAssertion)
+        case is ASAuthorizationPlatformPublicKeyCredentialRegistration:
+            logger.debug("switch passkey registration")
+            handleRegistration(authorization.credential as! ASAuthorizationPlatformPublicKeyCredentialRegistration)
+#if HARDWARE_KEY_SUPPORT
+        case is ASAuthorizationSecurityKeyPublicKeyCredentialRegistration:
+            logger.debug("switch hardware key registration")
+            handleRegistration(authorization.credential as! ASAuthorizationSecurityKeyPublicKeyCredentialRegistration)
+        case is ASAuthorizationSecurityKeyPublicKeyCredentialAssertion:
+            logger.debug("switch hardware key assn")
+            handleAssertion(authorization.credential as! ASAuthorizationSecurityKeyPublicKeyCredentialAssertion)
+#endif
+        default:
+            // TODO: Handle this properly
+            logger.error("uhh")
+        }
+    }
+
+    private func handleRegistration(
+        _ registration: ASAuthorizationPublicKeyCredentialRegistration
+    ) {
+        // Decode, send to SA, hand back resposne via delegate method
+        logger.info("got a registratoin response")
+
+        let credentialId = Base64URL(from: registration.credentialID)
+
+        /*
+         Leaving transports out for now
+        if let secKey = registration as? ASAuthorizationSecurityKeyPublicKeyCredentialRegistration {
+            if #available(iOS 17.5, *) {
+                let transports = secKey.transports.map { Transport(from: $0) }
+            } else {
+                // Fallback on earlier versions
+            }
+        }
+         */
+        guard registration.rawAttestationObject != nil else {
+            logger.error("No attestation")
+            return
+        }
+
+
+        let response = SAProcessRegisterRequest.RegCredential.RegResponse(
+            clientDataJSON: Base64URL(from: registration.rawClientDataJSON),
+            attestationObject: Base64URL(from: registration.rawAttestationObject!),
+            transports: [])
+        let credential = SAProcessRegisterRequest.RegCredential(
+            rawId: credentialId,
+            response: response)
+        let body = SAProcessRegisterRequest(credential: credential)
+
+        Task {
+            let tokenResponse = await api.makeRequest(
+                path: "/registration/process",
+                body: body,
+                type: SAProcessAuthResponse.self)
+            if tokenResponse == nil {
+                logger.debug("no/invalid process response")
+                /// TODO: delegate failure (network error?)
+                return
+            }
+            logger.debug("got token response")
+            let rewrapped = SnapAuthAuth(
+                token: tokenResponse!.result.token,
+                expiresAt: tokenResponse!.result.expiresAt)
+
+            await delegate?.snapAuth(didFinishRegistration: .success(rewrapped))
+        }
+    }
+
+    private func handleAssertion(
+        _ assertion: ASAuthorizationPublicKeyCredentialAssertion
+    ) {
+
+        // This can (will always?) be `nil` when using, at least, a hardware key
+        let userHandle = assertion.userID != nil
+            ? Base64URL(from: assertion.userID)
+            : nil
+
+        // If userHandle is nil, guard that we have userInfo since it's required on the BE
+
+
+        let credentialId = Base64URL(from: assertion.credentialID)
+        let response = SAProcessAuthRequest.SACredential.Response(
+            authenticatorData: Base64URL(from: assertion.rawAuthenticatorData),
+            clientDataJSON: Base64URL(from: assertion.rawClientDataJSON),
+            signature: Base64URL(from: assertion.signature),
+            userHandle: userHandle)
+
+        let cCrd = SAProcessAuthRequest.SACredential(
+            rawId: credentialId,
+            response: response)
+        let body = SAProcessAuthRequest(
+            credential: cCrd,
+            user: authenticatingUser)
+        logger.debug("made a body")
+//        logger.debug("user id \(assertion.userID.base64EncodedString())")
+        Task {
+            let tokenResponse = await api.makeRequest(
+                path: "/auth/process",
+                body: body,
+                type: SAProcessAuthResponse.self)
+            if tokenResponse == nil {
+                logger.debug("no/invalid process response")
+                /// TODO: delegate failure (network error?)
+                return
+            }
+            logger.debug("got token response")
+            let rewrapped = SnapAuthAuth(
+                token: tokenResponse!.result.token,
+                expiresAt: tokenResponse!.result.expiresAt)
+
+            await delegate?.snapAuth(didFinishAuthentication: .success(rewrapped))
+        }
+
+    }
+//
+//    public func authorizationController(_ controller: ASAuthorizationController, didCompleteWithCustomMethod method: ASAuthorizationCustomMethod) {
+//        if method == .other {
+//
+//        }
+//    }
+}
+

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -122,7 +122,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 return
             }
             logger.debug("got token response")
-            let rewrapped = SnapAuthAuth(
+            let rewrapped = SnapAuthTokenInfo(
                 token: tokenResponse!.result.token,
                 expiresAt: tokenResponse!.result.expiresAt)
 
@@ -168,7 +168,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 return
             }
             logger.debug("got token response")
-            let rewrapped = SnapAuthAuth(
+            let rewrapped = SnapAuthTokenInfo(
                 token: tokenResponse!.result.token,
                 expiresAt: tokenResponse!.result.expiresAt)
 

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -116,15 +116,19 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 path: "/registration/process",
                 body: body,
                 type: SAProcessAuthResponse.self)
-            if tokenResponse == nil {
+            guard tokenResponse != nil else {
                 logger.debug("no/invalid process response")
                 // TODO: delegate failure (network error?)
                 return
             }
+            guard tokenResponse!.result != nil else {
+                // TODO: bubble this up
+                return
+            }
             logger.debug("got token response")
             let rewrapped = SnapAuthTokenInfo(
-                token: tokenResponse!.result.token,
-                expiresAt: tokenResponse!.result.expiresAt)
+                token: tokenResponse!.result!.token,
+                expiresAt: tokenResponse!.result!.expiresAt)
 
             await delegate?.snapAuth(didFinishRegistration: .success(rewrapped))
         }
@@ -162,15 +166,19 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 path: "/auth/process",
                 body: body,
                 type: SAProcessAuthResponse.self)
-            if tokenResponse == nil {
+            guard tokenResponse != nil else {
                 logger.debug("no/invalid process response")
                 // TODO: delegate failure (network error?)
                 return
             }
+            guard tokenResponse!.result != nil else {
+                // TODO: bubble this up
+                return
+            }
             logger.debug("got token response")
             let rewrapped = SnapAuthTokenInfo(
-                token: tokenResponse!.result.token,
-                expiresAt: tokenResponse!.result.expiresAt)
+                token: tokenResponse!.result!.token,
+                expiresAt: tokenResponse!.result!.expiresAt)
 
             await delegate?.snapAuth(didFinishAuthentication: .success(rewrapped))
         }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -34,10 +34,15 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         // ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
 
         Task {
-            // Failure reason, etc, etc
-//            await delegate?.snapAuth(didAuthenticate: .failure)
-            // TODO: This needs to be aware of current flow (MAJOR)
-            await delegate?.snapAuth(didFinishAuthentication: .failure(.asAuthorizationError))
+            if (state == .authenticating) {
+                await delegate?.snapAuth(didFinishAuthentication: .failure(.asAuthorizationError))
+            } else if (state == .registering) {
+                await delegate?.snapAuth(didFinishRegistration: .failure(.asAuthorizationError))
+            } else if (state == .autofill) {
+                // Intentional no-op
+            }
+
+            state = .idle
         }
     }
 
@@ -171,7 +176,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         }
 
     }
-//
+// tvOS only? Probably not needed.
 //    public func authorizationController(_ controller: ASAuthorizationController, didCompleteWithCustomMethod method: ASAuthorizationCustomMethod) {
 //        if method == .other {
 //

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -118,7 +118,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 type: SAProcessAuthResponse.self)
             if tokenResponse == nil {
                 logger.debug("no/invalid process response")
-                /// TODO: delegate failure (network error?)
+                // TODO: delegate failure (network error?)
                 return
             }
             logger.debug("got token response")
@@ -164,7 +164,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 type: SAProcessAuthResponse.self)
             if tokenResponse == nil {
                 logger.debug("no/invalid process response")
-                /// TODO: delegate failure (network error?)
+                // TODO: delegate failure (network error?)
                 return
             }
             logger.debug("got token response")

--- a/Sources/SnapAuth/SnapAuth+ASACPCP.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACPCP.swift
@@ -1,0 +1,10 @@
+import AuthenticationServices
+
+// MARK: ASAuthConPresConProv
+@available(macOS 12.0, iOS 15.0, tvOS 16.0, visionOS 1.0, *)
+extension SnapAuth: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        logger.debug("presentation anchor")
+        return anchor!
+    }
+}

--- a/Sources/SnapAuth/SnapAuth+ASACPCP.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACPCP.swift
@@ -1,9 +1,10 @@
 import AuthenticationServices
 
-// MARK: ASAuthConPresConProv
+// MARK: ASAuthorizationControllerPresentationContextProviding
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, visionOS 1.0, *)
 extension SnapAuth: ASAuthorizationControllerPresentationContextProviding {
     public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        // FIXME: do not force unwrap
         logger.debug("presentation anchor")
         return anchor!
     }

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -33,8 +33,7 @@ extension SnapAuth {
             body: [:] as [String:String],
             type: SACreateAuthOptionsResponse.self)!
 
-        /// TODO: passkey only here
-        let authRequests = buildAuthRequests(from: parsed.result)
+        let authRequests = buildAuthRequests(from: parsed.result, keyTypes: [.passkey])
 
         let controller = ASAuthorizationController(authorizationRequests: authRequests)
         authController = controller

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -8,26 +8,28 @@ import AuthenticationServices
  */
 #if os(iOS) || os(visionOS)
 extension SnapAuth {
-    /**
-     Starts the AutoFill process using a default ASPresentationAnchor
-     */
+
+    /// Starts the AutoFill process using a default ASPresentationAnchor
     @available(iOS 16.0, *)
     public func handleAutoFill() async {
-        await handleAutoFill(anchor: ASPresentationAnchor())
+        await handleAutoFill(anchor: .default)
     }
 
+    /// Use the specified anchor. 
+    /// This may be exposed publiy if needed, but the intent/goal is the default is (almost) always correct
     @available(iOS 16.0, *)
-    public func handleAutoFill(anchor: ASPresentationAnchor) async {
+    internal func handleAutoFill(anchor: ASPresentationAnchor) async {
         self.anchor = anchor
 
         await handleAutoFill(presentationContextProvider: self)
     }
 
-
+    /// Use the specified presentationContextProvider.
+    /// Like with handleAutoFill(anchor:) this could get publicly exposed later but is for the "file a bug" case
     @available(iOS 16.0, *)
-    public func handleAutoFill(presentationContextProvider: ASAuthorizationControllerPresentationContextProviding) async {
+    internal func handleAutoFill(presentationContextProvider: ASAuthorizationControllerPresentationContextProviding) async {
         reset()
-        logger.debug("AF PCP start")
+        state = .autofill
         let parsed = await api.makeRequest(
             path: "/auth/createOptions",
             body: [:] as [String:String],

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -27,7 +27,9 @@ extension SnapAuth {
     /// Use the specified presentationContextProvider.
     /// Like with handleAutoFill(anchor:) this could get publicly exposed later but is for the "file a bug" case
     @available(iOS 16.0, *)
-    internal func handleAutoFill(presentationContextProvider: ASAuthorizationControllerPresentationContextProviding) async {
+    internal func handleAutoFill(
+        presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
+    ) async {
         reset()
         state = .autofill
         let parsed = await api.makeRequest(
@@ -35,7 +37,10 @@ extension SnapAuth {
             body: [:] as [String:String],
             type: SACreateAuthOptionsResponse.self)!
 
-        let authRequests = buildAuthRequests(from: parsed.result, keyTypes: [.passkey])
+        // AutoFill always only uses passkeys, so this is not configurable
+        let authRequests = buildAuthRequests(
+            from: parsed.result,
+            authenticators: [.passkey])
 
         let controller = ASAuthorizationController(authorizationRequests: authRequests)
         authController = controller

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -3,10 +3,10 @@ import AuthenticationServices
 /**
  Adds AutoFill passkey support.
 
- Due to platform limitations, this is only available on iOS.
+ Due to platform limitations, this is only available on iOS and visionOS.
  It is not (currently) supported on macOS, watchOS, tvOS, or Catalyst.
  */
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 extension SnapAuth {
     /**
      Starts the AutoFill process using a default ASPresentationAnchor

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -1,11 +1,11 @@
 import AuthenticationServices
 
-/**
- Adds AutoFill passkey support.
-
- Due to platform limitations, this is only available on iOS and visionOS.
- It is not (currently) supported on macOS, watchOS, tvOS, or Catalyst.
- */
+/// Adds AutoFill passkey support.
+///
+/// Due to platform limitations, this is only available on iOS and visionOS.
+/// It is not (currently) supported on macOS, watchOS, tvOS, or Catalyst.
+///
+/// Also, it doesn't seem to work _even on_ supported platforms.
 #if os(iOS) || os(visionOS)
 extension SnapAuth {
 
@@ -15,7 +15,7 @@ extension SnapAuth {
         await handleAutoFill(anchor: .default)
     }
 
-    /// Use the specified anchor. 
+    /// Use the specified anchor.
     /// This may be exposed publiy if needed, but the intent/goal is the default is (almost) always correct
     @available(iOS 16.0, *)
     internal func handleAutoFill(anchor: ASPresentationAnchor) async {

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -37,9 +37,15 @@ extension SnapAuth {
             body: [:] as [String:String],
             type: SACreateAuthOptionsResponse.self)!
 
+        guard parsed.result != nil else {
+            logger.error("no result for AF")
+            // TODO: bubble this up
+            return
+        }
+
         // AutoFill always only uses passkeys, so this is not configurable
         let authRequests = buildAuthRequests(
-            from: parsed.result,
+            from: parsed.result!,
             authenticators: [.passkey])
 
         let controller = ASAuthorizationController(authorizationRequests: authRequests)

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -1,0 +1,51 @@
+import AuthenticationServices
+
+/**
+ Adds AutoFill passkey support.
+
+ Due to platform limitations, this is only available on iOS.
+ It is not (currently) supported on macOS, watchOS, tvOS, or Catalyst.
+ */
+#if os(iOS)
+extension SnapAuth {
+    /**
+     Starts the AutoFill process using a default ASPresentationAnchor
+     */
+    @available(iOS 16.0, *)
+    public func handleAutoFill() async {
+        await handleAutoFill(anchor: ASPresentationAnchor())
+    }
+
+    @available(iOS 16.0, *)
+    public func handleAutoFill(anchor: ASPresentationAnchor) async {
+        self.anchor = anchor
+
+        await handleAutoFill(presentationContextProvider: self)
+    }
+
+
+    @available(iOS 16.0, *)
+    public func handleAutoFill(presentationContextProvider: ASAuthorizationControllerPresentationContextProviding) async {
+        reset()
+        logger.debug("AF PCP start")
+        let parsed = await api.makeRequest(
+            path: "/auth/createOptions",
+            body: [:] as [String:String],
+            type: SACreateAuthOptionsResponse.self)!
+
+        let challenge = parsed.result.publicKey.challenge.toData()!
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
+            relyingPartyIdentifier: parsed.result.publicKey.rpId)
+        let request = provider.createCredentialAssertionRequest(
+            challenge: challenge)
+
+
+        let controller = ASAuthorizationController(authorizationRequests: [request])
+        authController = controller
+        controller.delegate = self
+        controller.presentationContextProvider = presentationContextProvider
+        logger.debug("AF perform")
+        controller.performAutoFillAssistedRequests()
+    }
+}
+#endif

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -33,14 +33,10 @@ extension SnapAuth {
             body: [:] as [String:String],
             type: SACreateAuthOptionsResponse.self)!
 
-        let challenge = parsed.result.publicKey.challenge.toData()!
-        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
-            relyingPartyIdentifier: parsed.result.publicKey.rpId)
-        let request = provider.createCredentialAssertionRequest(
-            challenge: challenge)
+        /// TODO: passkey only here
+        let authRequests = buildAuthRequests(from: parsed.result)
 
-
-        let controller = ASAuthorizationController(authorizationRequests: [request])
+        let controller = ASAuthorizationController(authorizationRequests: authRequests)
         authController = controller
         controller.delegate = self
         controller.presentationContextProvider = presentationContextProvider

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -54,13 +54,16 @@ extension SnapAuth {
             let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rpId)
 
-            /// Process the `allowedCredentials` so the authenticator knows what it can use
-            let allowed = options.publicKey.allowCredentials!.map {
+            // Process the `allowedCredentials` so the authenticator knows what
+            // it can use. API responses omit this for AutoFill requests.
+            let allowed = options.publicKey.allowCredentials?.map {
                 ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: $0.id.toData()!)
             }
 
             let request = provider.createCredentialAssertionRequest(challenge: challenge)
-            request.allowedCredentials = allowed
+            if allowed != nil {
+                request.allowedCredentials = allowed!
+            }
             requests.append(request)
         }
 

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -14,7 +14,8 @@ extension SnapAuth {
         from options: SACreateRegisterOptionsResponse,
         name: String,
         displayName: String?,
-        keyTypes: [SnapAuth.KeyType]) -> [ASAuthorizationRequest] {
+        keyTypes: [SnapAuth.KeyType]
+    ) -> [ASAuthorizationRequest] {
         let challenge = options.publicKey.challenge.toData()!
 
         // Passkeys
@@ -38,5 +39,38 @@ extension SnapAuth {
         hwRequest.credentialParameters = [.init(algorithm: .ES256)] // TODO: API
 
         return [request, hwRequest]
+    }
+
+    internal func buildAuthRequests(
+        from options: SACreateAuthOptionsResponse
+    ) -> [ASAuthorizationRequest] {
+        // https://developer.apple.com/videos/play/wwdc2022/10092/ ~ 12:05
+
+        let challenge = options.publicKey.challenge.toData()!
+
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
+            relyingPartyIdentifier: options.publicKey.rpId)
+
+        /// Process the `allowedCredentials` so the authenticator knows what it can use
+        let allowed = options.publicKey.allowCredentials!.map {
+            ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: $0.id.toData()!)
+        }
+
+
+        let request = provider.createCredentialAssertionRequest(challenge: challenge)
+        request.allowedCredentials = allowed
+
+
+        let p2 = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
+            relyingPartyIdentifier: options.publicKey.rpId)
+        let r2 = p2.createCredentialAssertionRequest(challenge: challenge)
+        let a2 = options.publicKey.allowCredentials!.map {
+            ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor(
+                credentialID: $0.id.toData()!,
+                transports: ASAuthorizationSecurityKeyPublicKeyCredentialDescriptor.Transport.allSupported) /// TODO: the API should hint this
+        }
+        r2.allowedCredentials = a2
+
+        return [request, r2]
     }
 }

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -6,13 +6,13 @@ extension SnapAuth {
         from options: SACreateRegisterOptionsResponse,
         name: String,
         displayName: String?,
-        keyTypes: Set<SnapAuth.KeyType>
+        authenticators: Set<SnapAuth.Authenticator>
     ) -> [ASAuthorizationRequest] {
         let challenge = options.publicKey.challenge.toData()!
 
         var requests: [ASAuthorizationRequest] = []
 
-        if keyTypes.contains(.passkey) {
+        if authenticators.contains(.passkey) {
             let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rp.id)
             let request = provider.createCredentialRegistrationRequest(
@@ -24,7 +24,7 @@ extension SnapAuth {
         }
 
 #if HARDWARE_KEY_SUPPORT
-        if keyTypes.contains(.securityKey) {
+        if authenticators.contains(.securityKey) {
             let provider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rp.id)
             let request = provider.createCredentialRegistrationRequest(
@@ -44,13 +44,13 @@ extension SnapAuth {
 
     internal func buildAuthRequests(
         from options: SACreateAuthOptionsResponse,
-        keyTypes: Set<SnapAuth.KeyType>
+        authenticators: Set<SnapAuth.Authenticator>
     ) -> [ASAuthorizationRequest] {
         let challenge = options.publicKey.challenge.toData()!
 
         var requests: [ASAuthorizationRequest] = []
 
-        if keyTypes.contains(.passkey) {
+        if authenticators.contains(.passkey) {
             let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rpId)
 
@@ -65,7 +65,7 @@ extension SnapAuth {
         }
 
 #if HARDWARE_KEY_SUPPORT
-        if keyTypes.contains(.securityKey) {
+        if authenticators.contains(.securityKey) {
 
             let provider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rpId)

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -46,8 +46,6 @@ extension SnapAuth {
         from options: SACreateAuthOptionsResponse,
         keyTypes: Set<SnapAuth.KeyType>
     ) -> [ASAuthorizationRequest] {
-        // https://developer.apple.com/videos/play/wwdc2022/10092/ ~ 12:05
-
         let challenge = options.publicKey.challenge.toData()!
 
         var requests: [ASAuthorizationRequest] = []

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -14,7 +14,7 @@ extension SnapAuth {
         from options: SACreateRegisterOptionsResponse,
         name: String,
         displayName: String?,
-        keyTypes: [SnapAuth.KeyType]
+        keyTypes: Set<SnapAuth.KeyType>
     ) -> [ASAuthorizationRequest] {
         let challenge = options.publicKey.challenge.toData()!
 

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -8,7 +8,7 @@
 import AuthenticationServices
 
 //import Foundation
-
+@available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 extension SnapAuth {
     internal func buildRegisterRequests(
         from options: SACreateRegisterOptionsResponse,
@@ -47,6 +47,10 @@ extension SnapAuth {
         }
 #endif
 
+        #if os(tvOS)
+        requests.append(ASAuthorizationPasswordProvider().createRequest())
+//        requests.append(ASAuthorizationCustomMethod.other)
+        #endif
         return requests
     }
 
@@ -89,7 +93,11 @@ extension SnapAuth {
             requests.append(request)
         }
 #endif
-
+#if os(tvOS)
+        return [ASAuthorizationPasswordProvider().createRequest()]
+//requests.append(ASAuthorizationPasswordProvider().createRequest())
+//        requests.append(ASAuthorizationCustomMethod.other)
+#endif
         return requests
     }
 }

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -1,0 +1,42 @@
+//
+//  File.swift
+//  
+//
+//  Created by Eric Stern on 5/17/24.
+//
+
+import AuthenticationServices
+
+//import Foundation
+
+extension SnapAuth {
+    internal func buildRegisterRequests(
+        from options: SACreateRegisterOptionsResponse,
+        name: String,
+        displayName: String?,
+        keyTypes: [SnapAuth.KeyType]) -> [ASAuthorizationRequest] {
+        let challenge = options.publicKey.challenge.toData()!
+
+        // Passkeys
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(
+            relyingPartyIdentifier: options.publicKey.rp.id)
+        let request = provider.createCredentialRegistrationRequest(
+            challenge: challenge,
+            name: name,
+            userID: options.publicKey.user.id.toData()!)
+
+        /// TODO: filter tvOS+visionOS AND based on attn pref
+        // Hardware keys
+        let hwProvider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
+            relyingPartyIdentifier: options.publicKey.rp.id)
+        let hwRequest = hwProvider.createCredentialRegistrationRequest(
+            challenge: challenge,
+            displayName: name, 
+            name: name,
+            userID: options.publicKey.user.id.toData()!)
+        hwRequest.attestationPreference = .direct // TODO: API
+        hwRequest.credentialParameters = [.init(algorithm: .ES256)] // TODO: API
+
+        return [request, hwRequest]
+    }
+}

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -1,13 +1,5 @@
-//
-//  File.swift
-//
-//
-//  Created by Eric Stern on 5/17/24.
-//
-
 import AuthenticationServices
 
-//import Foundation
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 extension SnapAuth {
     internal func buildRegisterRequests(
@@ -47,10 +39,6 @@ extension SnapAuth {
         }
 #endif
 
-        #if os(tvOS)
-        requests.append(ASAuthorizationPasswordProvider().createRequest())
-//        requests.append(ASAuthorizationCustomMethod.other)
-        #endif
         return requests
     }
 
@@ -92,11 +80,6 @@ extension SnapAuth {
             request.allowedCredentials = allowed
             requests.append(request)
         }
-#endif
-#if os(tvOS)
-        return [ASAuthorizationPasswordProvider().createRequest()]
-//requests.append(ASAuthorizationPasswordProvider().createRequest())
-//        requests.append(ASAuthorizationCustomMethod.other)
 #endif
         return requests
     }

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -31,7 +31,7 @@ extension SnapAuth {
             requests.append(request)
         }
 
-#if !os(visionOS) && !os(tvOS)
+#if HARDWARE_KEY_SUPPORT
         if keyTypes.contains(.securityKey) {
             let provider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rp.id)
@@ -74,7 +74,7 @@ extension SnapAuth {
             requests.append(request)
         }
 
-#if !os(visionOS) && !os(tvOS)
+#if HARDWARE_KEY_SUPPORT
         if keyTypes.contains(.securityKey) {
 
             let provider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -125,7 +125,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         controller.performRequests()
     }
 
-    internal var authenticatingUser: SAUser?
+    internal var authenticatingUser: AuthenticatingUser?
 
     /// Starts the authentication process.
     /// Upon completion, the delegate will be called with either success or failure.
@@ -136,7 +136,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     ///
     /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
     public func startAuth(
-        _ user: SAUser,
+        _ user: AuthenticatingUser,
         authenticators: Set<Authenticator> = Authenticator.all
     ) async {
         await startAuth(user, anchor: .default, authenticators: authenticators)
@@ -144,7 +144,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
     /// This may be exposed publicly if the default anchor proves insufficient
     internal func startAuth(
-        _ user: SAUser,
+        _ user: AuthenticatingUser,
         anchor: ASPresentationAnchor,
         authenticators: Set<Authenticator> = Authenticator.all
     ) async {
@@ -196,7 +196,7 @@ enum State {
     case autofill
 }
 
-public enum SAUser {
+public enum AuthenticatingUser {
     /// Your application's internal identifier for the user (usually a primary key)
     case id(String)
     /// The user's handle, such as a username or email address
@@ -204,7 +204,7 @@ public enum SAUser {
 }
 
 /// Encode as JSON to either `{"id": id}` or `{"handle": handle}`, which is what the SnapAuth APIs need
-extension SAUser: Encodable {
+extension AuthenticatingUser: Encodable {
     enum CodingKeys: String, CodingKey {
          case id
          case handle

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -127,10 +127,14 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 
     private var authenticatingUser: SAUser?
-    /**
+    /*
      TODO: this should take a new UserInfo
      */
-    public func startAuth(_ user: SAUser, anchor: ASPresentationAnchor, keyTypes: [KeyType] = KeyType.all) async {
+    public func startAuth(
+        _ user: SAUser,
+        anchor: ASPresentationAnchor,
+        keyTypes: Set<KeyType> = KeyType.all
+    ) async {
         reset()
         self.anchor = anchor
         self.authenticatingUser = user
@@ -146,11 +150,10 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         logger.debug("before controller")
 
 
-        /// TODO: look at providers to fill in `requests`
-        let authRequests = buildAuthRequests(from: parsed.result)
+        let authRequests = buildAuthRequests(from: parsed.result, keyTypes: keyTypes)
 
-        /// Set up the native controller and start the request(s).
-        /// The UI should show the sheet to use a passkey or security key
+        // Set up the native controller and start the request(s).
+        // The UI should show the sheet to use a passkey or security key
         let controller = ASAuthorizationController(authorizationRequests: authRequests)
         authController = controller
         logger.debug("setting delegate")

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -40,19 +40,16 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 
     /// Permitted authenticator types
-    public enum Authenticator {
+    public enum Authenticator: CaseIterable {
+        /// Allow all available authenticator types to be used
+        public static let all = Set(Authenticator.allCases)
+
         /// Prompt for passkeys.
         case passkey
 
         #if HARDWARE_KEY_SUPPORT
         /// Prompt for hardware keys. This is not available on all platforms.
         case securityKey
-
-        /// Allow all available authenticator types to be used
-        public static let all: Set<Authenticator> = [.passkey, .securityKey]
-        #else
-        /// Allow all available authenticator types to be used
-        public static let all: Set<Authenticator> = [.passkey]
         #endif
     }
 

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -1,2 +1,251 @@
-// The Swift Programming Language
-// https://docs.swift.org/swift-book
+//
+//  SnapAuth.swift
+//  PassKeyExample
+//
+//  Created by Eric Stern on 3/15/24.
+//
+
+import Foundation
+import os // logger
+import AuthenticationServices
+
+
+/**
+ Related setup for SnapAuth:
+
+ The app MUST have an Associated Domains entitlement configured
+ 1) add `webcredentials:yourrpid.com` into the list
+    1) This must match the RP ID displayed on SnapAuth for your API key
+    2) You MAY amend `?mode=developer` to the value. If so, you MUST turn on SWC Developer Mode: `sudo swcutil developer-mode -e 1` (https://forums.developer.apple.com/forums/thread/743890)
+ 2) Associated Domains only works with a paid developer account, and possibly only one on a team (with DUNS number, etc.)
+  It is restricted from use on free accounts, which is outside of our control
+ 3) The domain must have a corresponding Associated Domains file: https://developer.apple.com/documentation/xcode/supporting-associated-domains
+    1) https://yourdomain.com/.well-known/apple-app-site-association must exist
+    2) It must serve valid JSON with association data
+    3) `.webcredentials.apps.[]` must exist and contain your app identifier (you may need to go into the developer portal to get this. It may contain multiple apps
+
+
+ */
+@available(macOS 12.0, *)
+public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
+    private let publishableKey: String
+    private let urlBase: URL
+
+    private let logger: Logger
+
+    public var delegate: SnapAuthDelegate?
+
+
+    private var anchor: ASPresentationAnchor?
+
+    public init(publishableKey: String,
+//         delegate: SnapAuthDelegate,
+         urlBase: URL = URL(string: "https://api.snapauth.app")!
+    ) {
+        self.publishableKey = publishableKey
+//        self.delegate = delegate
+        self.urlBase = urlBase
+        self.logger = Logger()
+    }
+
+    /**
+     TODO: this should take a new UserInfo
+     */
+    public func startAuth(_ user: SAUser, anchor: ASPresentationAnchor) async {
+        self.anchor = anchor
+        let body: [String: [String: String]]
+        switch user {
+        case .id(let id):
+            body = ["user": ["id": id]]
+        case .handle(let handle):
+            body = ["user": ["handle": handle]]
+        }
+
+        let parsed = await makeRequest(path: "/auth/createOptions", body: body, type: SACreateAuthOptions.self)!
+
+
+//        logger.debug("parsed ok")
+//        logger.debug("\(parsed.result.publicKey.challenge)")
+
+        let challenge = parsed.result.publicKey.challenge.toData()!
+        let provider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: parsed.result.publicKey.rpId)
+//        logger.debug("RP: \(parsed.result.publicKey.rpId)")
+        let request = provider.createCredentialAssertionRequest(challenge: challenge)
+
+
+        let allowed = parsed.result.publicKey.allowCredentials.map {
+            ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: $0.id.toData()!)
+        }
+        request.allowedCredentials = allowed
+
+        // this works, will need to decode differently
+//        let p2 = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(relyingPartyIdentifier: parsed.result.publicKey.rpId)
+//        let r2 = p2.createCredentialAssertionRequest(challenge: challenge)
+        logger.debug("before controller")
+        let controller = ASAuthorizationController(authorizationRequests: [request]) // + r2
+        logger.debug("setting delegate")
+        controller.delegate = self
+        controller.presentationContextProvider = self
+        logger.debug("perform requests")
+        controller.performRequests()
+        logger.debug("performed requests")
+
+        //  Sometimes the controller just WILL NOT CALL EITHER DELEGATE METHOD, so... yeah.
+
+    }
+
+    /// Internal API call wrapper
+    private func makeRequest<T>(path: String, body: Encodable, type: T.Type) async -> SAResponse<T>? {
+        let url = urlBase.appendingPathComponent(path)
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.setValue(basic, forHTTPHeaderField: "Authorization")
+        let json = try! JSONEncoder().encode(body)
+        request.httpBody = json
+
+        let (data, response) = try! await URLSession.shared.data(for: request)
+        let jsonString = String(data: data, encoding: .utf8)
+        logger.debug("\(jsonString ?? "not a string")")
+
+        guard let parsed = try? JSONDecoder().decode(SAResponse<T>.self, from: data) else {
+            logger.error("nope")
+            return nil
+        }
+
+        return parsed
+    }
+
+    /// Auth header generation
+    var basic: String {
+        return "Basic " + Data("\(publishableKey):".utf8).base64EncodedString()
+    }
+
+}
+
+@available(macOS 12.0, *)
+extension SnapAuth: ASAuthorizationControllerDelegate {
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        logger.error("ASACD fail: \(error)")
+        // (lldb) po error
+        // Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app" UserInfo={NSLocalizedFailureReason=Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app}
+        // (lldb) po error.localizedDescription
+        // "The operation couldn’t be completed. Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app"
+
+        Task {
+            // Failure reason, etc, etc
+            await delegate?.snapAuth(didAuthenticate: .failure)
+        }
+    }
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        logger.debug("ASACD did complete")
+
+        // This cast may be different if arriving from a physical key?
+        guard let assertion = authorization.credential as? ASAuthorizationPlatformPublicKeyCredentialAssertion else {
+            logger.error("not assertion???")
+            return
+        }
+
+        let cRes = SAProcessAuthRequest.SACredential.Response(
+            authenticatorData: Base64URL(from: assertion.rawAuthenticatorData),
+            clientDataJSON: Base64URL(from: assertion.rawClientDataJSON),
+            signature: Base64URL(from: assertion.signature),
+            userHandle: Base64URL(from: assertion.userID)
+        )
+        let cCrd = SAProcessAuthRequest.SACredential(rawId: Base64URL(from: assertion.credentialID), response: cRes)
+        let body = SAProcessAuthRequest(credential: cCrd)
+        logger.debug("made a body")
+        logger.debug("user id \(assertion.userID.base64EncodedString())")
+        Task {
+            let tokenResponse = await makeRequest(path: "/auth/process", body: body, type: SAAuthData.self)
+            if tokenResponse == nil {
+                logger.debug("no/invalid process response")
+                return
+            }
+            logger.debug("got token response")
+
+            await delegate?.snapAuth(didAuthenticate: .success(tokenResponse!.result))
+
+        }
+    }
+}
+@available(macOS 12.0, *)
+extension SnapAuth: ASAuthorizationControllerPresentationContextProviding {
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        logger.debug("presentation anchor")
+        return anchor!
+
+        // This almost certainly doesn't work right on iOS and seems to occasionally misbehave on macOS.
+        // The SDK should be platform-agnostic... which may mean this is user-configurable?
+//        #if os(macOS)
+//            return NSApplication.shared.mainWindow ?? ASPresentationAnchor()
+//        #else
+//            return UIApplication.shared.keyWindow!
+//        #endif
+    }
+
+
+}
+
+public enum SAUser {
+    // TODO: codable here to simplify generation request?
+//    case anonymous
+    case id(String)
+    case handle(String)
+}
+
+// just decodable? Also, build this on top of Result<S,E>?
+struct SAResponse<T>: Codable where T: Codable {
+    let result: T
+}
+struct SACreateAuthOptions: Codable {
+    let publicKey: PublicKeyOptions
+    // mediation
+
+    struct PublicKeyOptions: Codable {
+
+        struct AllowCredential: Codable {
+            let type: String // == "public-key"
+            let id: Base64URL
+            // transports?
+        }
+
+        let rpId: String
+        let challenge: Base64URL
+        let allowCredentials: [AllowCredential]
+    }
+}
+
+public struct SAAuthData: Codable {
+    public let token: String
+    // expiresAt
+}
+
+struct SAProcessAuthRequest: Codable {
+    // user ~ id/handle (skip for now since this is passkey only flow...ish)
+    let credential: SACredential
+    struct SACredential: Codable {
+        let type: String = "public-key"
+        let rawId: Base64URL
+        let response: SACredential.Response
+        struct Response: Codable {
+            let authenticatorData: Base64URL
+            let clientDataJSON: Base64URL
+            let signature: Base64URL
+            let userHandle: Base64URL // todo: optional
+        }
+    }
+
+}
+
+
+public enum SAAuthResponse {
+    case success(SAAuthData)
+    case failure // TODO: associated data
+}
+
+public protocol SnapAuthDelegate {
+    // optional?
+    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async
+}

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -59,8 +59,6 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 
     public enum KeyType {
-        /// Allow all available authenticator types to be used
-        public static let all: [KeyType] = [.passkey, .securityKey]
 
         /// Prompt for passkeys
         case passkey
@@ -68,6 +66,12 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         #if !os(tvOS) && !os(visionOS)
         /// Prompt for hardware keys. This is not available on all platforms
         case securityKey
+
+        /// Allow all available authenticator types to be used
+        public static let all: [KeyType] = [.passkey, .securityKey]
+        #else
+        /// Allow all available authenticator types to be used
+        public static let all: [KeyType] = [.passkey]
         #endif
     }
 

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -118,13 +118,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         self.anchor = anchor
         self.authenticatingUser = user
 
-        let body: [String: [String: String]]
-        switch user {
-        case .id(let id):
-            body = ["user": ["id": id]]
-        case .handle(let handle):
-            body = ["user": ["handle": handle]]
-        }
+        let body = ["user": user]
 
         let parsed = await api.makeRequest(
             path: "/auth/createOptions",

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -63,7 +63,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         /// Prompt for passkeys
         case passkey
 
-        #if !os(tvOS) && !os(visionOS)
+        #if HARDWARE_KEY_SUPPORT
         /// Prompt for hardware keys. This is not available on all platforms
         case securityKey
 

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -45,6 +45,8 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
     private var anchor: ASPresentationAnchor?
 
+    private var authController: ASAuthorizationController?
+
     public init(publishableKey: String,
 //         delegate: SnapAuthDelegate,
          urlBase: URL = URL(string: "https://api.snapauth.app")!
@@ -86,6 +88,9 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     private func reset() -> Void {
 //        self.anchor = nil
         self.authenticatingUser = nil
+        if #available(iOS 16.0, *) {
+            cancelAutoFillAssistedPasskeySignIn()
+        }
     }
 
     /**
@@ -107,10 +112,20 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
 
         let controller = ASAuthorizationController(authorizationRequests: [request])
+        authController = controller
         controller.delegate = self
         controller.presentationContextProvider = presentationContextProvider
         logger.debug("AF perform")
         controller.performAutoFillAssistedRequests()
+    }
+
+    @available(iOS 16.0, *)
+    func cancelAutoFillAssistedPasskeySignIn() {
+        logger.debug("cancel AF")
+        if authController != nil {
+           authController!.cancel()
+           authController = nil
+         }
     }
     #endif
 
@@ -169,6 +184,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         /// Set up the native controller and start the request(s).
         /// The UI should show the sheet to use a passkey or security key
         let controller = ASAuthorizationController(authorizationRequests: [request, r2]) // + r2
+        authController = controller
         logger.debug("setting delegate")
         controller.delegate = self
         controller.presentationContextProvider = self

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -62,14 +62,13 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             logger: logger)
     }
 
-    /// An enumeration of WebAuthn authenticators that are permitted
+    /// Permitted authenticator types
     public enum KeyType {
-
-        /// Prompt for passkeys
+        /// Prompt for passkeys.
         case passkey
 
         #if HARDWARE_KEY_SUPPORT
-        /// Prompt for hardware keys. This is not available on all platforms
+        /// Prompt for hardware keys. This is not available on all platforms.
         case securityKey
 
         /// Allow all available authenticator types to be used
@@ -80,9 +79,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         #endif
     }
 
-    /**
-     Reinitializes internal state before starting a request.
-     */
+    /// Reinitializes internal state before starting a request.
     internal func reset() -> Void {
         self.authenticatingUser = nil
         cancelPendingRequest()
@@ -100,6 +97,12 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         }
     }
 
+    /// Starts the passkey enrollment process.
+    /// - Parameters:
+    ///   - name: The name of the user.
+    ///   - displayName: The proper name of the user. If omitted, name will be used.
+    ///   - keyTypes: What authenticators should be permitted. If omitted, 
+    ///   all available types for the platform will be allowed.
     public func startRegister(
         name: String,
         displayName: String? = nil,
@@ -112,7 +115,8 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             keyTypes: keyTypes)
     }
 
-    public func startRegister(
+    // TODO: Only make this public if needed?
+    internal func startRegister(
         name: String,
         anchor: ASPresentationAnchor,
         displayName: String? = nil,
@@ -146,7 +150,11 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
     internal var authenticatingUser: SAUser?
 
-    /// Preferred method to start authentication
+    /// Starts the authentication process.
+    ///
+    /// - Parameters:
+    ///   - user: The authenticating user's `id` or `handle`
+    ///   - keyTypes: What authenticators should be permitted. If omitted, all available types for the platform will be allowed.
     public func startAuth(
         _ user: SAUser,
         keyTypes: Set<KeyType> = KeyType.all
@@ -154,7 +162,8 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         await startAuth(user, anchor: .default, keyTypes: keyTypes)
     }
 
-    public func startAuth(
+    ///
+    internal func startAuth(
         _ user: SAUser,
         anchor: ASPresentationAnchor,
         keyTypes: Set<KeyType> = KeyType.all
@@ -194,7 +203,10 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     internal var state: State = .idle
 }
 
-/// An enumeration of SDK state, which enables sending appropriate failure messages back to delegates
+/// SDK state
+///
+/// This helps with sending appropriate failure messages back to delegates,
+/// since all AS delegate failure paths go to a single place.
 enum State {
     case idle
     case registering
@@ -203,12 +215,13 @@ enum State {
 }
 
 public enum SAUser {
+    /// Your application's internal identifier for the user (usually a primary key)
     case id(String)
+    /// The user's handle, such as a username or email address
     case handle(String)
 }
-/**
- Encode to either `{"id": id}` or `{"handle": handle}`
- */
+
+/// Encode as JSON to either `{"id": id}` or `{"handle": handle}`, which is what the SnapAuth APIs need
 extension SAUser: Encodable {
     enum CodingKeys: String, CodingKey {
          case id

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -36,7 +36,7 @@ Known issues:
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
 
-    /// The delegate that SnapAuth informs about the success or failure of an authorization attempt.
+    /// The delegate that SnapAuth informs about the success or failure of an operation.
     public var delegate: SnapAuthDelegate?
 
     internal let api: SnapAuthClient

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -68,10 +68,10 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         case securityKey
 
         /// Allow all available authenticator types to be used
-        public static let all: [KeyType] = [.passkey, .securityKey]
+        public static let all: Set<KeyType> = [.passkey, .securityKey]
         #else
         /// Allow all available authenticator types to be used
-        public static let all: [KeyType] = [.passkey]
+        public static let all: Set<KeyType> = [.passkey]
         #endif
     }
 
@@ -99,7 +99,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         name: String,
         anchor: ASPresentationAnchor,
         displayName: String? = nil,
-        keyTypes: [KeyType] = KeyType.all
+        keyTypes: Set<KeyType> = KeyType.all
     ) async {
         reset()
         self.anchor = anchor

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -69,6 +69,11 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     // TODO, determine other platforms
     #if os(iOS)
     @available(iOS 16.0, *)
+    public func handleAutofill() async {
+        await handleAutofill(anchor: ASPresentationAnchor())
+    }
+
+    @available(iOS 16.0, *)
     public func handleAutofill(anchor: ASPresentationAnchor) async {
         self.anchor = anchor
 

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -50,6 +50,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
     internal let logger: Logger
 
+    // TODO: weak (all of these)?
     internal var presentationContextProvider: ASAuthorizationControllerPresentationContextProviding?
 
     internal var anchor: ASPresentationAnchor?

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -9,13 +9,13 @@ import Foundation
 import os // logger
 import AuthenticationServices
 
-/**
+/*
  Resources:
  - https://developer.apple.com/videos/play/wwdc2021/10106/
  - https://developer.apple.com/videos/play/wwdc2022/10092/
  */
 
-/**
+/*
  Related setup for SnapAuth:
 
  The app MUST have an Associated Domains entitlement configured
@@ -35,6 +35,11 @@ Known issues:
  - autofill will not start
 
  */
+
+/// The SnapAuth SDK.
+///
+/// This is used to start the passkey registration and authentication processes,
+/// typically in the `action` of a `Button`
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
 
@@ -51,6 +56,11 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
     internal var authController: ASAuthorizationController?
 
+    /// - Parameters:
+    ///   - publishableKey: Your SnapAuth publishable key. This can be obtained
+    ///   from the [SnapAuth dashboard](https://dashboard.snapauth.app)
+    ///   - urlBase: A custom URL base for the SnapAuth API. This is generally
+    ///   for internal use.
     public init(
        publishableKey: String,
        urlBase: URL = URL(string: "https://api.snapauth.app")!
@@ -98,11 +108,14 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 
     /// Starts the passkey enrollment process.
+    /// Upon completion, the delegate will be called with either success or failure.
     /// - Parameters:
     ///   - name: The name of the user.
     ///   - displayName: The proper name of the user. If omitted, name will be used.
     ///   - keyTypes: What authenticators should be permitted. If omitted, 
     ///   all available types for the platform will be allowed.
+    ///
+    /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
     public func startRegister(
         name: String,
         displayName: String? = nil,
@@ -151,10 +164,13 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     internal var authenticatingUser: SAUser?
 
     /// Starts the authentication process.
+    /// Upon completion, the delegate will be called with either success or failure.
     ///
     /// - Parameters:
     ///   - user: The authenticating user's `id` or `handle`
     ///   - keyTypes: What authenticators should be permitted. If omitted, all available types for the platform will be allowed.
+    ///
+    /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
     public func startAuth(
         _ user: SAUser,
         keyTypes: Set<KeyType> = KeyType.all
@@ -162,7 +178,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         await startAuth(user, anchor: .default, keyTypes: keyTypes)
     }
 
-    ///
+    /// This may be exposed publicly if the default anchor proves insufficient
     internal func startAuth(
         _ user: SAUser,
         anchor: ASPresentationAnchor,

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -2,33 +2,6 @@ import AuthenticationServices
 import Foundation
 import os
 
-/*
- Resources:
- - https://developer.apple.com/videos/play/wwdc2021/10106/
- - https://developer.apple.com/videos/play/wwdc2022/10092/
- */
-
-/*
- Related setup for SnapAuth:
-
- The app MUST have an Associated Domains entitlement configured
- 1) add `webcredentials:yourrpid.com` into the list
-    1) This must match the RP ID displayed on SnapAuth for your API key
-    2) You MAY amend `?mode=developer` to the value. If so, you MUST turn on SWC Developer Mode: `sudo swcutil developer-mode -e 1` (https://forums.developer.apple.com/forums/thread/743890)
- 2) Associated Domains only works with a paid developer account, and possibly only one on a team (with DUNS number, etc.)
-  It is restricted from use on free accounts, which is outside of our control
- 3) The domain must have a corresponding Associated Domains file: https://developer.apple.com/documentation/xcode/supporting-associated-domains
-    1) https://yourdomain.com/.well-known/apple-app-site-association must exist
-    2) It must serve valid JSON with association data
-    3) `.webcredentials.apps.[]` must exist and contain your app identifier (you may need to go into the developer portal to get this. It may contain multiple apps
-
-
-Known issues:
- - tvOS will not present any dialog, full stop
- - autofill will not start
-
- */
-
 /// The SnapAuth SDK.
 ///
 /// This is used to start the passkey registration and authentication processes,

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -30,6 +30,10 @@ import AuthenticationServices
     3) `.webcredentials.apps.[]` must exist and contain your app identifier (you may need to go into the developer portal to get this. It may contain multiple apps
 
 
+Known issues:
+ - tvOS will not present any dialog, full stop
+ - autofill will not start
+
  */
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
@@ -126,7 +130,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         controller.performRequests()
     }
 
-    private var authenticatingUser: SAUser?
+    internal var authenticatingUser: SAUser?
     /*
      TODO: this should take a new UserInfo
      */
@@ -158,6 +162,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         authController = controller
         logger.debug("setting delegate")
         controller.delegate = self
+        logger.debug("setting presentation context")
         controller.presentationContextProvider = self
         logger.debug("perform requests")
         controller.performRequests()
@@ -169,195 +174,6 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 }
 
-// MARK: ASAuthConDel
-@available(macOS 12.0, iOS 15.0, visionOS 1.0, tvOS 16.0, *)
-extension SnapAuth: ASAuthorizationControllerDelegate {
-
-    public func authorizationController(
-        controller: ASAuthorizationController,
-        didCompleteWithError error: Error
-    ) {
-        // TODO: don't bubble this up if it's from an autofill request
-        if let asError = error as? ASAuthorizationError {
-//            asError.code == .canceled
-
-
-            logger.error("ASACD \(asError.errorCode)")
-            // 1001 = no credentials available
-//        case unknown = 1000
-//        case canceled = 1001
-//        case invalidResponse = 1002
-//        case notHandled = 1003
-//        case failed = 1004
-//        case notInteractive = 1005
-        }
-        logger.error("ASACD fail: \(error)")
-        // (lldb) po error
-        // Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app" UserInfo={NSLocalizedFailureReason=Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app}
-        // (lldb) po error.localizedDescription
-        // "The operation couldn’t be completed. Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app"
-
-        // The start call can SILENTLY produce this error which never makes it into this handler
-        // ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
-
-        Task {
-            // Failure reason, etc, etc
-//            await delegate?.snapAuth(didAuthenticate: .failure)
-            // TODO: This needs to be aware of current flow (MAJOR)
-            await delegate?.snapAuth(didFinishAuthentication: .failure(.asAuthorizationError))
-        }
-    }
-
-    public func authorizationController(
-        controller: ASAuthorizationController,
-        didCompleteWithAuthorization authorization: ASAuthorization
-    ) {
-        if delegate == nil {
-            logger.error("No SnapAuth delegate set")
-            return
-        }
-        logger.debug("ASACD did complete")
-
-
-        switch authorization.credential {
-        case is ASAuthorizationPlatformPublicKeyCredentialAssertion:
-            logger.debug("switch passkey assn")
-            handleAssertion(authorization.credential as! ASAuthorizationPlatformPublicKeyCredentialAssertion)
-        case is ASAuthorizationPlatformPublicKeyCredentialRegistration:
-            logger.debug("switch passkey registration")
-            handleRegistration(authorization.credential as! ASAuthorizationPlatformPublicKeyCredentialRegistration)
-#if HARDWARE_KEY_SUPPORT
-        case is ASAuthorizationSecurityKeyPublicKeyCredentialRegistration:
-            logger.debug("switch hardware key registration")
-            handleRegistration(authorization.credential as! ASAuthorizationSecurityKeyPublicKeyCredentialRegistration)
-        case is ASAuthorizationSecurityKeyPublicKeyCredentialAssertion:
-            logger.debug("switch hardware key assn")
-            handleAssertion(authorization.credential as! ASAuthorizationSecurityKeyPublicKeyCredentialAssertion)
-#endif
-        default:
-            // TODO: Handle this properly
-            logger.error("uhh")
-        }
-    }
-
-    private func handleRegistration(
-        _ registration: ASAuthorizationPublicKeyCredentialRegistration
-    ) {
-        // Decode, send to SA, hand back resposne via delegate method
-        logger.info("got a registratoin response")
-
-        let credentialId = Base64URL(from: registration.credentialID)
-
-        /*
-         Leaving transports out for now
-        if let secKey = registration as? ASAuthorizationSecurityKeyPublicKeyCredentialRegistration {
-            if #available(iOS 17.5, *) {
-                let transports = secKey.transports.map { Transport(from: $0) }
-            } else {
-                // Fallback on earlier versions
-            }
-        }
-         */
-        guard registration.rawAttestationObject != nil else {
-            logger.error("No attestation")
-            return
-        }
-
-
-        let response = SAProcessRegisterRequest.RegCredential.RegResponse(
-            clientDataJSON: Base64URL(from: registration.rawClientDataJSON),
-            attestationObject: Base64URL(from: registration.rawAttestationObject!),
-            transports: [])
-        let credential = SAProcessRegisterRequest.RegCredential(
-            rawId: credentialId,
-            response: response)
-        let body = SAProcessRegisterRequest(credential: credential)
-
-        Task {
-            let tokenResponse = await api.makeRequest(
-                path: "/registration/process",
-                body: body,
-                type: SAProcessAuthResponse.self)
-            if tokenResponse == nil {
-                logger.debug("no/invalid process response")
-                /// TODO: delegate failure (network error?)
-                return
-            }
-            logger.debug("got token response")
-            let rewrapped = SnapAuthAuth(
-                token: tokenResponse!.result.token,
-                expiresAt: tokenResponse!.result.expiresAt)
-
-            await delegate?.snapAuth(didFinishRegistration: .success(rewrapped))
-        }
-    }
-
-    private func handleAssertion(
-        _ assertion: ASAuthorizationPublicKeyCredentialAssertion
-    ) {
-
-        // This can (will always?) be `nil` when using, at least, a hardware key
-        let userHandle = assertion.userID != nil
-            ? Base64URL(from: assertion.userID)
-            : nil
-
-        // If userHandle is nil, guard that we have userInfo since it's required on the BE
-
-
-        let credentialId = Base64URL(from: assertion.credentialID)
-        let response = SAProcessAuthRequest.SACredential.Response(
-            authenticatorData: Base64URL(from: assertion.rawAuthenticatorData),
-            clientDataJSON: Base64URL(from: assertion.rawClientDataJSON),
-            signature: Base64URL(from: assertion.signature),
-            userHandle: userHandle)
-
-        let cCrd = SAProcessAuthRequest.SACredential(
-            rawId: credentialId,
-            response: response)
-        let body = SAProcessAuthRequest(
-            credential: cCrd,
-            user: authenticatingUser)
-        logger.debug("made a body")
-//        logger.debug("user id \(assertion.userID.base64EncodedString())")
-        Task {
-            let tokenResponse = await api.makeRequest(
-                path: "/auth/process",
-                body: body,
-                type: SAProcessAuthResponse.self)
-            if tokenResponse == nil {
-                logger.debug("no/invalid process response")
-                /// TODO: delegate failure (network error?)
-                return
-            }
-            logger.debug("got token response")
-            let rewrapped = SnapAuthAuth(
-                token: tokenResponse!.result.token,
-                expiresAt: tokenResponse!.result.expiresAt)
-
-            await delegate?.snapAuth(didFinishAuthentication: .success(rewrapped))
-        }
-
-    }
-}
-
-// MARK: ASAuthConPresConProv
-@available(macOS 12.0, iOS 15.0, tvOS 16.0, visionOS 1.0, *)
-extension SnapAuth: ASAuthorizationControllerPresentationContextProviding {
-    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        logger.debug("presentation anchor")
-        return anchor!
-
-        // This almost certainly doesn't work right on iOS and seems to occasionally misbehave on macOS.
-        // The SDK should be platform-agnostic... which may mean this is user-configurable?
-//        #if os(macOS)
-//            return NSApplication.shared.mainWindow ?? ASPresentationAnchor()
-//        #else
-//            return UIApplication.shared.keyWindow!
-//        #endif
-    }
-
-
-}
 
 public enum SAUser {
     case id(String)

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -40,7 +40,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 
     /// Permitted authenticator types
-    public enum KeyType {
+    public enum Authenticator {
         /// Prompt for passkeys.
         case passkey
 
@@ -49,10 +49,10 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         case securityKey
 
         /// Allow all available authenticator types to be used
-        public static let all: Set<KeyType> = [.passkey, .securityKey]
+        public static let all: Set<Authenticator> = [.passkey, .securityKey]
         #else
         /// Allow all available authenticator types to be used
-        public static let all: Set<KeyType> = [.passkey]
+        public static let all: Set<Authenticator> = [.passkey]
         #endif
     }
 
@@ -79,20 +79,20 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     /// - Parameters:
     ///   - name: The name of the user.
     ///   - displayName: The proper name of the user. If omitted, name will be used.
-    ///   - keyTypes: What authenticators should be permitted. If omitted,
+    ///   - authenticators: What authenticators should be permitted. If omitted,
     ///   all available types for the platform will be allowed.
     ///
     /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
     public func startRegister(
         name: String,
         displayName: String? = nil,
-        keyTypes: Set<KeyType> = KeyType.all
+        authenticators: Set<Authenticator> = Authenticator.all
     ) async {
         await startRegister(
             name: name,
             anchor: .default,
             displayName: displayName,
-            keyTypes: keyTypes)
+            authenticators: authenticators)
     }
 
     // TODO: Only make this public if needed?
@@ -100,7 +100,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         name: String,
         anchor: ASPresentationAnchor,
         displayName: String? = nil,
-        keyTypes: Set<KeyType> = KeyType.all
+        authenticators: Set<Authenticator> = Authenticator.all
     ) async {
         reset()
         self.anchor = anchor
@@ -117,7 +117,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             from: options.result,
             name: name,
             displayName: displayName,
-            keyTypes: keyTypes)
+            authenticators: authenticators)
 
 
         let controller = ASAuthorizationController(authorizationRequests: authRequests)
@@ -135,21 +135,21 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     ///
     /// - Parameters:
     ///   - user: The authenticating user's `id` or `handle`
-    ///   - keyTypes: What authenticators should be permitted. If omitted, all available types for the platform will be allowed.
+    ///   - authenticators: What authenticators should be permitted. If omitted, all available types for the platform will be allowed.
     ///
     /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
     public func startAuth(
         _ user: SAUser,
-        keyTypes: Set<KeyType> = KeyType.all
+        authenticators: Set<Authenticator> = Authenticator.all
     ) async {
-        await startAuth(user, anchor: .default, keyTypes: keyTypes)
+        await startAuth(user, anchor: .default, authenticators: authenticators)
     }
 
     /// This may be exposed publicly if the default anchor proves insufficient
     internal func startAuth(
         _ user: SAUser,
         anchor: ASPresentationAnchor,
-        keyTypes: Set<KeyType> = KeyType.all
+        authenticators: Set<Authenticator> = Authenticator.all
     ) async {
         reset()
         self.anchor = anchor
@@ -167,7 +167,9 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         logger.debug("before controller")
 
 
-        let authRequests = buildAuthRequests(from: parsed.result, keyTypes: keyTypes)
+        let authRequests = buildAuthRequests(
+            from: parsed.result,
+            authenticators: authenticators)
 
         // Set up the native controller and start the request(s).
         // The UI should show the sheet to use a passkey or security key

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -1,13 +1,6 @@
-//
-//  SnapAuth.swift
-//  PassKeyExample
-//
-//  Created by Eric Stern on 3/15/24.
-//
-
-import Foundation
-import os // logger
 import AuthenticationServices
+import Foundation
+import os
 
 /*
  Resources:
@@ -113,7 +106,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     /// - Parameters:
     ///   - name: The name of the user.
     ///   - displayName: The proper name of the user. If omitted, name will be used.
-    ///   - keyTypes: What authenticators should be permitted. If omitted, 
+    ///   - keyTypes: What authenticators should be permitted. If omitted,
     ///   all available types for the platform will be allowed.
     ///
     /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -109,9 +109,13 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             body: body,
             type: SACreateRegisterOptionsResponse.self)!
 
+        guard options.result != nil else {
+            // TODO: bubble error
+            return
+        }
 
         let authRequests = buildRegisterRequests(
-            from: options.result,
+            from: options.result!,
             name: name,
             displayName: displayName,
             authenticators: authenticators)
@@ -161,11 +165,14 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             type: SACreateAuthOptionsResponse.self)!
 
 
+        guard parsed.result != nil else {
+            // TODO: bubble error
+            return
+        }
+
         logger.debug("before controller")
-
-
         let authRequests = buildAuthRequests(
-            from: parsed.result,
+            from: parsed.result!,
             authenticators: authenticators)
 
         // Set up the native controller and start the request(s).

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public protocol SnapAuthDelegate {
-    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async
+//    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async
 //    func snapAuth(didRegister registrationResponse: SAAuthResponse) async
     // didBeginProcessing(registration/authn/autofill)
 
-    func sa(didAuth auth: Result<SnapAuthAuth, AuthenticationError>) async
+    func snapAuth(didFinishAuthentication result: Result<SnapAuthAuth, AuthenticationError>) async
 }
 /*
  extension SnapAuthDelegate {
@@ -16,6 +16,7 @@ public protocol SnapAuthDelegate {
 */
 
 /// TODO: rename this!
+/// Also, can this be a typealias of the wire format internal?
 public struct SnapAuthAuth {
   public let token: String
   public let expiresAt: Date

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public protocol SnapAuthDelegate {
+    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async
+//    func snapAuth(didRegister registrationResponse: SAAuthResponse) async
+    // didBeginProcessing(registration/authn/autofill)
+
+    func sa(didAuth auth: Result<SnapAuthAuth, AuthenticationError>) async
+}
+/*
+ extension SnapAuthDelegate {
+//    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async {
+//        // No-op by default
+//    }
+}
+*/
+
+/// TODO: rename this!
+public struct SnapAuthAuth {
+  public let token: String
+  public let expiresAt: Date
+}

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,21 +1,11 @@
 import Foundation
 
 public protocol SnapAuthDelegate {
-//    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async
-//    func snapAuth(didRegister registrationResponse: SAAuthResponse) async
-    // didBeginProcessing(registration/authn/autofill)
-
     func snapAuth(didFinishAuthentication result: Result<SnapAuthAuth, AuthenticationError>) async
 
     func snapAuth(didFinishRegistration result: Result<SnapAuthAuth, AuthenticationError>) async
 }
-/*
- extension SnapAuthDelegate {
-//    func snapAuth(didAuthenticate authenticationResponse: SAAuthResponse) async {
-//        // No-op by default
-//    }
-}
-*/
+
 
 /// TODO: rename this!
 /// Also, can this be a typealias of the wire format internal?

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,15 +1,24 @@
 import Foundation
 
 public protocol SnapAuthDelegate {
-    func snapAuth(didFinishAuthentication result: Result<SnapAuthAuth, AuthenticationError>) async
+    func snapAuth(didFinishAuthentication result: SnapAuthResult) async
 
-    func snapAuth(didFinishRegistration result: Result<SnapAuthAuth, AuthenticationError>) async
+    func snapAuth(didFinishRegistration result: SnapAuthResult) async
 }
 
+public struct SnapAuthTokenInfo {
+    /// The registration or authentication token.
+    ///
+    /// This cannot be used directly by your client app.
+    /// It must be sent to your backend for verification, which will use a 
+    /// server SDK to either create a credential or verify the authentication.
+    public let token: String
 
-/// TODO: rename this!
-/// Also, can this be a typealias of the wire format internal?
-public struct SnapAuthAuth {
-  public let token: String
-  public let expiresAt: Date
+    /// When the paired token will expire.
+    ///
+    /// If you try to use it after this time (or more than once), the request
+    /// will be rejected.
+    public let expiresAt: Date
 }
+
+public typealias SnapAuthResult = Result<SnapAuthTokenInfo, AuthenticationError>

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,8 +1,39 @@
 import Foundation
 
+/// An interface for providing information about the outcome of a SnapAuth request
 public protocol SnapAuthDelegate {
+    /// Tells the delegate when SnapAuth finished a modal authentication request.
+    ///
+    /// Implementations should examine the result to determine if it was a
+    /// success or failure, and proceed accordingly.
+    ///
+    /// ```
+    /// func snapAuth(didFinishAuthentication result: SnapAuthResult) async {
+    ///     switch result {
+    ///     case .success(let auth):
+    ///         // Send auth.token to your backend
+    ///     case .failure(let error):
+    ///         // Examine error to decide how to proceed
+    ///     }
+    /// }
+    /// ```
     func snapAuth(didFinishAuthentication result: SnapAuthResult) async
 
+    /// Tells the delegate when SnapAuth finished a registration request.
+    ///
+    /// Implementations should examine the result to determine if it was a
+    /// success or failure, and proceed accordingly.
+    ///
+    /// ```
+    /// func snapAuth(didFinishRegistration result: SnapAuthResult) async {
+    ///     switch result {
+    ///     case .success(let registration):
+    ///         // Send registration.token to your backend
+    ///     case .failure(let error):
+    ///         // Examine error to decide how to proceed
+    ///     }
+    /// }
+    /// ```
     func snapAuth(didFinishRegistration result: SnapAuthResult) async
 }
 
@@ -10,7 +41,7 @@ public struct SnapAuthTokenInfo {
     /// The registration or authentication token.
     ///
     /// This cannot be used directly by your client app.
-    /// It must be sent to your backend for verification, which will use a 
+    /// It must be sent to your backend for verification, which will use a
     /// server SDK to either create a credential or verify the authentication.
     public let token: String
 

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -6,6 +6,8 @@ public protocol SnapAuthDelegate {
     // didBeginProcessing(registration/authn/autofill)
 
     func snapAuth(didFinishAuthentication result: Result<SnapAuthAuth, AuthenticationError>) async
+
+    func snapAuth(didFinishRegistration result: Result<SnapAuthAuth, AuthenticationError>) async
 }
 /*
  extension SnapAuthDelegate {


### PR DESCRIPTION
This creates a basic iOS/macOS (/tvOS/visionOS?) SDK for integrating SnapAuth.

So far:
- Registration seems to work
- Model authentication seems to work
- Autofill authentication DOES NOT work (I can't find anything wrong logically, but the UI in the test app glitches out and gets console warnings when it's given the appropriate hint)

It's been tested on-device for macOS and iOS, and in simulators for visionOS (seems ok-ish given the limitations) and tvOS (basically non-functional, but I think this is a simulator problem)

Logging is a hot mess, error handling needs (a lot of) work, and a lot of the internal names are pretty goofy. I'll file issues for all of that.

BUT the core integration experience is _pretty decent_:

- Initialize with a publishable key
- Implement (and set) a delegate
- Call one of the two (three?) main APIs
- Get your callback

I'd prefer a more direct async/await approach, but this is probably the more native experience and trying to work through threading the `ASAuthorization` callbacks _back into_ async/await is probably not a good time.

```swift

import SwiftUI
import AuthenticationServices
import SnapAuth

struct ContentView: View {

    let snapAuth = SnapAuth(
        publishableKey: "pubkey_f73c62d953397a45edbf1e6a7a1ce6dc41d69a31")

    @State private var username: String = ""
    @State private var resultText: String = ""
    @State private var running = false

    var body: some View {
        VStack {
            Text("SnapAuth Example")
                .font(.title)

            Spacer()

            TextField("Username", text: $username)
                .textContentType(/*@START_MENU_TOKEN@*/.username/*@END_MENU_TOKEN@*/)
                .padding()

            Button("Sign In", systemImage: "person.badge.key") {
                running = true
                signIn()
            }.padding()

            Button("Register", systemImage: "person.badge.key.fill") {
                running = true
                register()
            }.padding()

            Text("Auth token: \(resultText)")

            if running {
                ProgressView()
            }

        }
//        .onAppear(perform: autoFill)
        .padding()
        .background(.purple)

        
    }

    func autoFill() {
        #if os(iOS)
        Task {
            snapAuth.delegate = self
            await snapAuth.handleAutoFill()
        }
        #endif
    }

    func register() {
        Task {
            snapAuth.delegate = self
            await snapAuth.startRegister(name: username)
        }
    }

    func signIn() {
        Task {
            snapAuth.delegate = self
            await snapAuth.startAuth(.handle(username))

            
        }
    }
}

extension ContentView: SnapAuthDelegate {

    func snapAuth(didFinishAuthentication result: SnapAuthResult) async {
        running = false
        guard case .success(let auth) = result else {
            resultText = "AUTH FAILED"
            return
        }
        resultText = "Auth succeeded: \(auth.token)"
    }

    func snapAuth(didFinishRegistration result: SnapAuthResult) async {
        running = false
        switch result {
        case .success(let registration):
            resultText = "Reg success \(registration.token)"
        case .failure(let error):
            resultText = "REG FAILED"
        }
    }
}
```

Specifically with loading it like this in SwiftUI and a single view, it's a bit error-prone, since you can easily forget to bind the delegate - and then everything silently fails.

There are also some Apple bugs where the internal ASAuthorization delegate methods aren't called in some failure scenarios, and the whole domain linking process is a pain. They're a bit tricky to repro but I'll file radars for all of them once I get it figured out.