### PR TITLE
Ensure that most SDK calls don't result in hanging delegates

### DIFF
--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -1,4 +1,4 @@
-// FIXME: Go through and ensure errors are complete and accurate.
+/* FIXME: Go through and ensure errors are complete and accurate.
 public enum AuthenticationError: Error {
     /// The user canceled
     case canceled
@@ -7,6 +7,7 @@ public enum AuthenticationError: Error {
 
     case asAuthorizationError
 }
+ */
 
 
 public enum SnapAuthError: Error {
@@ -21,4 +22,12 @@ public enum SnapAuthError: Error {
 
     /// The request was valid and understood, but processing was refused.
     case badRequest
+
+    // Duplicated (ish) from ASAuthorizationError
+    case unknown
+//    case canceled
+//    case invalidResponse
+//    case notHandled
+//    case failed
+//    case notInteractive
 }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -35,9 +35,9 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
 
         Task {
             if (state == .authenticating) {
-                await delegate?.snapAuth(didFinishAuthentication: .failure(.asAuthorizationError))
+                await delegate?.snapAuth(didFinishAuthentication: .failure(.unknown))
             } else if (state == .registering) {
-                await delegate?.snapAuth(didFinishRegistration: .failure(.asAuthorizationError))
+                await delegate?.snapAuth(didFinishRegistration: .failure(.unknown))
             } else if (state == .autofill) {
                 // Intentional no-op
             }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -97,6 +97,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         }
          */
         guard registration.rawAttestationObject != nil else {
+            // TODO: what should be done here?
             logger.error("No attestation")
             return
         }
@@ -117,8 +118,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 body: body,
                 type: SAProcessAuthResponse.self)
             guard case let .success(processAuth) = response else {
-                logger.debug("no/invalid process response")
-                // TODO: bubble this up via delegate failure (network error?)
+                logger.debug("/registration/process error")
+                await delegate?.snapAuth(didFinishRegistration: .failure(response.getError()!))
                 return
             }
             logger.debug("got token response")
@@ -163,8 +164,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 body: body,
                 type: SAProcessAuthResponse.self)
             guard case let .success(authResponse) = response else {
-                logger.debug("no/invalid process response")
-                // TODO: bubble this up via delegate failure (network error?)
+                logger.debug("/auth/process error")
+                await delegate?.snapAuth(didFinishAuthentication: .failure(response.getError()!))
                 return
             }
             logger.debug("got token response")

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -110,7 +110,8 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             type: SACreateRegisterOptionsResponse.self)
 
         guard case let .success(options) = response else {
-            // TODO: bubble error
+            let error = response.getError()!
+            await delegate?.snapAuth(didFinishRegistration: .failure(error))
             return
         }
 
@@ -166,7 +167,8 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
 
         guard case let .success(options) = response else {
-            // TODO: bubble error
+            let error = response.getError()!
+            await delegate?.snapAuth(didFinishAuthentication: .failure(error))
             return
         }
 
@@ -227,4 +229,15 @@ extension AuthenticatingUser: Encodable {
              try container.encode(value, forKey: .handle)
          }
      }
+}
+
+extension Result {
+    func getError() -> Failure? {
+        switch self {
+        case .success:
+            return nil
+        case .failure(let failure):
+            return failure
+        }
+    }
 }

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -231,6 +231,7 @@ extension AuthenticatingUser: Encodable {
      }
 }
 
+/// Small addition to the native Result type to more easily extract error details.
 extension Result {
     func getError() -> Failure? {
         switch self {

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -52,4 +52,4 @@ public struct SnapAuthTokenInfo {
     public let expiresAt: Date
 }
 
-public typealias SnapAuthResult = Result<SnapAuthTokenInfo, AuthenticationError>
+public typealias SnapAuthResult = Result<SnapAuthTokenInfo, SnapAuthError>


### PR DESCRIPTION
This tackles a handful of TODOs to call the failure case delegate method, ensuring that _most of the time_ if one of the public APIs is called, either of the appropriate delegate methods will also be called.

There's a couple others remaining that will also get addressed separately.

Progress on #2 and #3.