### PR TITLE
Call delegate failure in remaining cases

### DIFF
--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -23,6 +23,13 @@ public enum SnapAuthError: Error {
     /// The request was valid and understood, but processing was refused.
     case badRequest
 
+
+    /// ASAuthorizationServices sent SnapAuth an unexpected type of response which we don't know how to handle. If you encounter this, please reach out to us.
+    case unexpectedAuthorizationType
+
+    /// Some of the data SnapAuth requested during credential registration was not provided, so we cannot proceed.
+    case registrationDataMissing
+
     // Duplicated (ish) from ASAuthorizationError
     case unknown
 //    case canceled


### PR DESCRIPTION
This should handle all of the remaining cases where the delegate method might not be called in a failure scenario (excepting the case where `ASAuthorization` doesn't call _our_ delegate method, which is an upstream bug). The error codes are not correct in all situations, but theoretically will always result in a complete cycle.