### PR TITLE
Convert delegate API to async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,30 +150,6 @@ In any files that need to integrate with SnapAuth, be sure to import it:
 import SnapAuth
 ```
 
-### Implement `SnapAuthDelegate`
-
-If using SwiftUI, this can be done directly on a `View`.
-You may also do this in a separate class or struct.
-
-This will be called by our SDK when a user either authenticates or cancels the request.
-
-Example:
-```swift
-import SnapAuth
-
-func snapAuth(didFinishAuthentication result: SnapAuthTokenInfo) async {
-    guard case .success(let auth) = result else {
-        // User did not or could not authenticate.
-        return
-    }
-    // Send `auth.token` to your backend for server-side verification. Use it to
-    // determine the authenticating user, and send back an appropriate response
-    // to the client code.
-}
-```
-
-Registration is substantially the same.
-
 ### Call the API
 
 Grab your `publishable key` from the SnapAuth Dashboard; you'll use it below.
@@ -188,11 +164,11 @@ import SwiftUI
 struct SignInView: View {
   let snapAuth = SnapAuth(publishableKey: "pubkey_yourkey") // Set this value!
 
-  @State var username: String = ""
+  @State var userName: String = ""
 
   var body: some View {
     VStack {
-      TextField("Username", text: $username)
+      TextField("Username", text: $userName)
       Button("Sign In", systemImage: "person.badge.key") {
         signIn()
       }
@@ -201,13 +177,15 @@ struct SignInView: View {
 
   func signIn() {
     Task {
-      snapAuth.delegate = self
-      await snapAuth.startAuth(.handle(username), anchor: ASPresentationAnchor())
+      let result = await snapAuth.startAuth(.handle(userName))
+      switch result {
+      case .success(let auth):
+        // Send auth.token to your backend to sign in the user
+      case .failure(let error):
+        // Decide how to proceed
+      }
     }
   }
-}
-extension SignInView: SnapAuthDelegate {
-  // delegate methods described above
 }
 ```
 

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -91,8 +91,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         guard registration.rawAttestationObject != nil else {
             // This may change in the future?
             logger.error("No attestation in registration response")
-            registerContinuation?.resume(returning: .failure(.registrationDataMissing))
-//            sendError(.registrationDataMissing)
+            sendError(.registrationDataMissing)
             return
         }
 
@@ -110,11 +109,10 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
             let response = await api.makeRequest(
                 path: "/registration/process",
                 body: body,
-                type: SAProcessAuthResponse.self)
+                type: SAProcessAuthResponse.self) // TODO: rename this type
             guard case let .success(processAuth) = response else {
                 logger.debug("/registration/process error")
-//                await delegate?.snapAuth(didFinishRegistration: .failure(response.getError()!))
-                registerContinuation?.resume(returning: .failure(response.getError()!))
+                sendError(response.getError()!)
                 return
             }
             logger.debug("got token response")
@@ -123,7 +121,6 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 expiresAt: processAuth.expiresAt)
 
             registerContinuation?.resume(returning: .success(rewrapped))
-//            await delegate?.snapAuth(didFinishRegistration: .success(rewrapped))
         }
     }
 

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -64,7 +64,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         case .authenticating:
             Task { await delegate?.snapAuth(didFinishAuthentication: .failure(error)) }
         case .registering:
-            Task { await delegate?.snapAuth(didFinishRegistration: .failure(error)) }
+//            Task { await delegate?.snapAuth(didFinishRegistration: .failure(error)) }
+            registerContinuation?.resume(returning: .failure(error))
         case .idle:
             logger.error("Tried to send error in idle state")
         case .autofill:
@@ -95,7 +96,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         guard registration.rawAttestationObject != nil else {
             // This may change in the future?
             logger.error("No attestation in registration response")
-            sendError(.registrationDataMissing)
+            registerContinuation?.resume(returning: .failure(.registrationDataMissing))
+//            sendError(.registrationDataMissing)
             return
         }
 
@@ -116,7 +118,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 type: SAProcessAuthResponse.self)
             guard case let .success(processAuth) = response else {
                 logger.debug("/registration/process error")
-                await delegate?.snapAuth(didFinishRegistration: .failure(response.getError()!))
+//                await delegate?.snapAuth(didFinishRegistration: .failure(response.getError()!))
+                registerContinuation?.resume(returning: .failure(response.getError()!))
                 return
             }
             logger.debug("got token response")
@@ -124,7 +127,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 token: processAuth.token,
                 expiresAt: processAuth.expiresAt)
 
-            await delegate?.snapAuth(didFinishRegistration: .success(rewrapped))
+            registerContinuation?.resume(returning: .success(rewrapped))
+//            await delegate?.snapAuth(didFinishRegistration: .success(rewrapped))
         }
     }
 

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -10,7 +10,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
     ) {
 //        if case ASAuthorizationError.canceled = error {
 //        }
-        // TODO: don't bubble this up if it's from an autofill request
+        // TODO: don't bubble this up if it's from an autoFill request
         if let asError = error as? ASAuthorizationError {
 //            asError.code == .canceled
 
@@ -63,7 +63,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
             registerContinuation?.resume(returning: .failure(error))
         case .idle:
             logger.error("Tried to send error in idle state")
-        case .autofill:
+        case .autoFill:
             // No-op for now. TODO: decide what errors to send
             break
         }
@@ -169,9 +169,9 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
             if state == .authenticating {
                 // if AF, send to delegate, otherwise do this
                 authContinuation?.resume(returning: .success(rewrapped))
-            } else if state == .autofill {
+            } else if state == .autoFill {
                 assert(autoFillDelegate != nil, "AutoFill w/ no delegate")
-                autoFillDelegate?.snapAuth(didAutofillWithResult: .success(rewrapped))
+                autoFillDelegate?.snapAuth(didAutoFillWithResult: .success(rewrapped))
             } else {
                 assert(false, "Not authenticating or AF in assertion delegate")
             }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -40,10 +40,10 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
-        if delegate == nil {
-            logger.error("No SnapAuth delegate set")
-            return
-        }
+//        if delegate == nil {
+//            logger.error("No SnapAuth delegate set")
+//            return
+//        }
         logger.debug("ASACD did complete")
 
 
@@ -62,7 +62,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
     private func sendError(_ error: SnapAuthError) {
         switch state {
         case .authenticating:
-            Task { await delegate?.snapAuth(didFinishAuthentication: .failure(error)) }
+            authContinuation?.resume(returning: .failure(error))
+//            Task { await delegate?.snapAuth(didFinishAuthentication: .failure(error)) }
         case .registering:
 //            Task { await delegate?.snapAuth(didFinishRegistration: .failure(error)) }
             registerContinuation?.resume(returning: .failure(error))
@@ -166,7 +167,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 type: SAProcessAuthResponse.self)
             guard case let .success(authResponse) = response else {
                 logger.debug("/auth/process error")
-                await delegate?.snapAuth(didFinishAuthentication: .failure(response.getError()!))
+//                await delegate?.snapAuth(didFinishAuthentication: .failure(response.getError()!))
+                authContinuation?.resume(returning: .failure(response.getError()!))
                 return
             }
             logger.debug("got token response")
@@ -174,7 +176,8 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
                 token: authResponse.token,
                 expiresAt: authResponse.expiresAt)
 
-            await delegate?.snapAuth(didFinishAuthentication: .success(rewrapped))
+            authContinuation?.resume(returning: .success(rewrapped))
+//            await delegate?.snapAuth(didFinishAuthentication: .success(rewrapped))
         }
 
     }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -40,10 +40,6 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         controller: ASAuthorizationController,
         didCompleteWithAuthorization authorization: ASAuthorization
     ) {
-//        if delegate == nil {
-//            logger.error("No SnapAuth delegate set")
-//            return
-//        }
         logger.debug("ASACD did complete")
 
 

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -11,7 +11,7 @@ extension SnapAuth {
 
     /// Starts the AutoFill process using a default ASPresentationAnchor
     @available(iOS 16.0, *)
-    public func handleAutoFill(delegate: SnapAuthAutofillDelegate) {
+    public func handleAutoFill(delegate: SnapAuthAutoFillDelegate) {
         handleAutoFill(delegate: delegate, anchor: .default)
     }
 
@@ -19,7 +19,7 @@ extension SnapAuth {
     /// This may be exposed publiy if needed, but the intent/goal is the default is (almost) always correct
     @available(iOS 16.0, *)
     internal func handleAutoFill(
-        delegate: SnapAuthAutofillDelegate,
+        delegate: SnapAuthAutoFillDelegate,
         anchor: ASPresentationAnchor
     ) {
         self.anchor = anchor
@@ -31,7 +31,7 @@ extension SnapAuth {
     /// Like with handleAutoFill(anchor:) this could get publicly exposed later but is for the "file a bug" case
     @available(iOS 16.0, *)
     internal func handleAutoFill(
-        delegate: SnapAuthAutofillDelegate,
+        delegate: SnapAuthAutoFillDelegate,
         presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
     ) {
         reset()
@@ -64,7 +64,3 @@ extension SnapAuth {
 
 }
 #endif
-
-public protocol SnapAuthAutofillDelegate {
-    func snapAuth(didAutofillWithResult result: SnapAuthResult)
-}

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -11,27 +11,32 @@ extension SnapAuth {
 
     /// Starts the AutoFill process using a default ASPresentationAnchor
     @available(iOS 16.0, *)
-    public func handleAutoFill() async {
-        await handleAutoFill(anchor: .default)
+    public func handleAutoFill(delegate: SnapAuthAutofillDelegate) async {
+        await handleAutoFill(delegate: delegate, anchor: .default)
     }
 
     /// Use the specified anchor.
     /// This may be exposed publiy if needed, but the intent/goal is the default is (almost) always correct
     @available(iOS 16.0, *)
-    internal func handleAutoFill(anchor: ASPresentationAnchor) async {
+    internal func handleAutoFill(
+        delegate: SnapAuthAutofillDelegate,
+        anchor: ASPresentationAnchor
+    ) async {
         self.anchor = anchor
 
-        await handleAutoFill(presentationContextProvider: self)
+        await handleAutoFill(delegate: delegate, presentationContextProvider: self)
     }
 
     /// Use the specified presentationContextProvider.
     /// Like with handleAutoFill(anchor:) this could get publicly exposed later but is for the "file a bug" case
     @available(iOS 16.0, *)
     internal func handleAutoFill(
+        delegate: SnapAuthAutofillDelegate,
         presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
     ) async {
         reset()
         state = .autofill
+        autoFillDelegate = delegate
         let response = await api.makeRequest(
             path: "/auth/createOptions",
             body: [:] as [String:String],
@@ -54,5 +59,10 @@ extension SnapAuth {
         logger.debug("AF perform")
         controller.performAutoFillAssistedRequests()
     }
+
 }
 #endif
+
+public protocol SnapAuthAutofillDelegate {
+    func snapAuth(didAutofillWithResult result: SnapAuthResult)
+}

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -35,7 +35,7 @@ extension SnapAuth {
         presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
     ) {
         reset()
-        state = .autofill
+        state = .autoFill
         autoFillDelegate = delegate
         Task {
             let response = await api.makeRequest(

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -62,6 +62,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     internal func reset() -> Void {
         self.authenticatingUser = nil
         cancelPendingRequest()
+        state = .idle
     }
 
     private func cancelPendingRequest() {

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -85,7 +85,21 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     ///   - authenticators: What authenticators should be permitted. If omitted,
     ///   all available types for the platform will be allowed.
     ///
-    /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
+    /// - Returns: A `Result` containing either `SnapAuthTokenInfo` upon success
+    ///   or a `SnapAuthError` upon failure.
+    ///
+    /// # Example
+    /// ```swift
+    /// Task {
+    ///     let result = await snapAuth.startRegister(name: name)
+    ///     switch result {
+    ///     case .success(let registration):
+    ///         // send registration.token to your backend to create the credential
+    ///     case .failure(let error):
+    ///         // Examine the error and decide how best to proceed
+    ///     }
+    /// }
+    /// ```
     public func startRegister(
         name: String,
         displayName: String? = nil,
@@ -152,7 +166,22 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     ///   - user: The authenticating user's `id` or `handle`
     ///   - authenticators: What authenticators should be permitted. If omitted, all available types for the platform will be allowed.
     ///
-    /// - Returns: Nothing. Instead, the `SnapAuthDelegate` will be informed of the result.
+    ///
+    /// - Returns: A `Result` containing either `SnapAuthTokenInfo` upon success
+    ///   or a `SnapAuthError` upon failure.
+    ///
+    /// # Example
+    /// ```swift
+    /// Task {
+    ///     let result = await snapAuth.startAuth(.handle(userName))
+    ///     switch result {
+    ///     case .success(let auth):
+    ///         // send auth.token to your backend to verify
+    ///     case .failure(let error):
+    ///         // Examine the error and decide how best to proceed
+    ///     }
+    /// }
+    /// ```
     public func startAuth(
         _ user: AuthenticatingUser,
         authenticators: Set<Authenticator> = Authenticator.all

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -11,6 +11,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
     /// The delegate that SnapAuth informs about the success or failure of an operation.
 //    public var delegate: SnapAuthDelegate?
+    internal var autoFillDelegate: SnapAuthAutofillDelegate?
 
     internal let api: SnapAuthClient
 

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -9,9 +9,8 @@ import os
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
 
-    /// The delegate that SnapAuth informs about the success or failure of an operation.
-//    public var delegate: SnapAuthDelegate?
-    internal var autoFillDelegate: SnapAuthAutofillDelegate?
+    /// The delegate that SnapAuth informs about the success or failure of an AutoFill operation.
+    internal var autoFillDelegate: SnapAuthAutoFillDelegate?
 
     internal let api: SnapAuthClient
 
@@ -130,10 +129,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             type: SACreateRegisterOptionsResponse.self)
 
         guard case let .success(options) = response else {
-            let error = response.getError()!
-//            await delegate?.snapAuth(didFinishRegistration: .failure(error))
-
-            return .failure(error)
+            return .failure(response.getError()!)
         }
 
         let authRequests = buildRegisterRequests(
@@ -155,7 +151,6 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
         }
     }
-
 
     internal var authenticatingUser: AuthenticatingUser?
 
@@ -209,9 +204,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
 
         guard case let .success(options) = response else {
-            let error = response.getError()!
-//            await delegate?.snapAuth(didFinishAuthentication: .failure(error))
-            return .failure(error)
+            return .failure(response.getError()!)
         }
 
         logger.debug("before controller")

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -239,7 +239,7 @@ enum State {
     case idle
     case registering
     case authenticating
-    case autofill
+    case autoFill
 }
 
 public enum AuthenticatingUser {

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,40 +1,8 @@
 import Foundation
 
-/// An interface for providing information about the outcome of a SnapAuth request
-public protocol SnapAuthDelegate {
-    /// Tells the delegate when SnapAuth finished a modal authentication request.
-    ///
-    /// Implementations should examine the result to determine if it was a
-    /// success or failure, and proceed accordingly.
-    ///
-    /// ```
-    /// func snapAuth(didFinishAuthentication result: SnapAuthResult) async {
-    ///     switch result {
-    ///     case .success(let auth):
-    ///         // Send auth.token to your backend
-    ///     case .failure(let error):
-    ///         // Examine error to decide how to proceed
-    ///     }
-    /// }
-    /// ```
-    func snapAuth(didFinishAuthentication result: SnapAuthResult) async
-
-    /// Tells the delegate when SnapAuth finished a registration request.
-    ///
-    /// Implementations should examine the result to determine if it was a
-    /// success or failure, and proceed accordingly.
-    ///
-    /// ```
-    /// func snapAuth(didFinishRegistration result: SnapAuthResult) async {
-    ///     switch result {
-    ///     case .success(let registration):
-    ///         // Send registration.token to your backend
-    ///     case .failure(let error):
-    ///         // Examine error to decide how to proceed
-    ///     }
-    /// }
-    /// ```
-    func snapAuth(didFinishRegistration result: SnapAuthResult) async
+/// An interface for providing information about the outcome of a SnapAuth AutoFill request
+public protocol SnapAuthAutoFillDelegate {
+    func snapAuth(didAutofillWithResult result: SnapAuthResult)
 }
 
 public struct SnapAuthTokenInfo {

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// An interface for providing information about the outcome of a SnapAuth AutoFill request
 public protocol SnapAuthAutoFillDelegate {
-    func snapAuth(didAutofillWithResult result: SnapAuthResult)
+    func snapAuth(didAutoFillWithResult result: SnapAuthResult)
 }
 
 public struct SnapAuthTokenInfo {


### PR DESCRIPTION
This was the intended API from the start, and Continuations ended up being the trick to bridge the delegate-based ASAuthorization APIs into the SnapAuth SDKs.

Now, instead of setting the delegate and calling the method, the client code looks more like `let authInfo = await snapAuth.startauth(.handle(username))`. It should be more error-resistant (you can't fail to set the delegate, and will get a compiler warning if you ignore the result) and a bit easier and more streamlined to implement.

The AutoFill APIs remain delegate-based (following a structural adjustment), similar to how the JS/TS is passed a callback This is definitely open to adjustment based on feedback.

Fixes #18.