### PR TITLE
Improve error consistency and details

### DIFF
--- a/Sources/SnapAuth/ApiClient.swift
+++ b/Sources/SnapAuth/ApiClient.swift
@@ -59,6 +59,15 @@ struct SnapAuthClient {
 
         guard let wrapped = parsed.result else {
             // TODO: match all of the docuemented error types
+            // There's only a small subset that are (currently) reachable from
+            // client APIs:
+            // AuthenticatingUserAccountNotFound
+            // InvalidInput
+            // UsingDeactivatedCredential
+            // PublishableKeyNotFound
+            // InvalidAuthorizationHeader
+            //
+            // And, of those, most should be unreachable when actually using the SDK
             return .failure(.badRequest)
         }
         return .success(wrapped)

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -1,40 +1,51 @@
-/* FIXME: Go through and ensure errors are complete and accurate.
-public enum AuthenticationError: Error {
-    /// The user canceled
-    case canceled
-    /// There was a network interruption
-    case networkDisrupted
-
-    case asAuthorizationError
-}
- */
-
-
 public enum SnapAuthError: Error {
-    /// The network request was disrupted.
+    /// The network request was disrupted. This is generally safe to retry.
     case networkInterruption
 
-    /// The SDK received a response from SnapAuth, but it arrived in an unexpected format. If you encounter this, please reach out to us.
+    // MARK: Internal errors, which could represent SnapAuth bugs
+
+    /// The SDK received a response from SnapAuth, but it arrived in an
+    /// unexpected format. If you encounter this, please reach out to us.
     case malformedResposne
 
-    /// The SDK was unable to encode data to send to SnapAuth. If you ever encounter this, please reach out to us.
+    /// The SDK was unable to encode data to send to SnapAuth. If you encounter
+    /// this, please reach out to us.
     case sdkEncodingError
 
-    /// The request was valid and understood, but processing was refused.
+    /// The request was valid and understood, but processing was refused. If you
+    /// encounter this, please reach out to us.
     case badRequest
 
+    // MARK: Weird responses
 
-    /// ASAuthorizationServices sent SnapAuth an unexpected type of response which we don't know how to handle. If you encounter this, please reach out to us.
+    /// ASAuthorizationServices sent SnapAuth an unexpected type of response
+    /// which we don't know how to handle. If you encounter this, please reach
+    /// out to us.
     case unexpectedAuthorizationType
 
-    /// Some of the data SnapAuth requested during credential registration was not provided, so we cannot proceed.
+    /// Some of the data SnapAuth requested during credential registration was
+    /// not provided, so we cannot proceed.
     case registrationDataMissing
 
-    // Duplicated (ish) from ASAuthorizationError
+    // MARK: Duplicated/relayed from ASAuthorizationError
+
+    /// An unknown error occurred.
     case unknown
-//    case canceled
-//    case invalidResponse
-//    case notHandled
-//    case failed
-//    case notInteractive
+
+    /// Request canceled, which can either be explicit (such as the user
+    /// canceling) or implicit (such as no matching credentials available)
+    case canceled
+
+    /// There was an invalid response from the authenticator.
+    case invalidResponse
+
+    // (Usage unknown, Apple docs are not clear - timeout?)
+    case notHandled
+
+    /// Authorization failed. This is often due to incorrect setup of Associated
+    /// Domains, or an API key that does not match the Associated Domains.
+    case failed
+
+    // (Usage unknown, Apple docs are not clear)
+    case notInteractive
 }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -8,32 +8,28 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         controller: ASAuthorizationController,
         didCompleteWithError error: Error
     ) {
-//        if case ASAuthorizationError.canceled = error {
-//        }
-        // TODO: don't bubble this up if it's from an autoFill request
-        if let asError = error as? ASAuthorizationError {
-//            asError.code == .canceled
-
-
-            logger.error("ASACD \(asError.errorCode)")
-            // 1001 = no credentials available
-//        case unknown = 1000
-//        case canceled = 1001
-//        case invalidResponse = 1002
-//        case notHandled = 1003
-//        case failed = 1004
-//        case notInteractive = 1005
+        guard let asError = error as? ASAuthorizationError else {
+            logger.error("authorizationController didCompleteWithError error was not an ASAuthorizationError")
+            sendError(.unknown)
+            return
         }
-        logger.error("ASACD fail: \(error)")
-        // (lldb) po error
-        // Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app" UserInfo={NSLocalizedFailureReason=Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app}
-        // (lldb) po error.localizedDescription
-        // "The operation couldn’t be completed. Application with identifier V46X94865S.app.snapauth.PassKeyExample is not associated with domain demo.snapauth.app"
 
+        switch asError.code {
+        case .canceled:
+            sendError(.canceled)
+        case .failed:
+            sendError(.failed)
+        case .invalidResponse:
+            sendError(.invalidResponse)
+        case .notHandled:
+            sendError(.notHandled)
+        case .notInteractive:
+            sendError(.notInteractive)
+        @unknown default:
+            sendError(.unknown)
+        }
         // The start call can SILENTLY produce this error which never makes it into this handler
         // ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
-
-        sendError(.unknown)
     }
 
     public func authorizationController(
@@ -74,7 +70,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
         _ registration: ASAuthorizationPublicKeyCredentialRegistration
     ) {
         // Decode, send to SA, hand back resposne via delegate method
-        logger.info("got a registratoin response")
+        logger.info("got a registration response")
 
         let credentialId = Base64URL(from: registration.credentialID)
 


### PR DESCRIPTION
This adds a number of new error cases, and ensures that we match up to them when the AS delegate indicates an error.

Fixes #2 and makes progress on #3.