### PR TITLE
Clean up last remaining unguarded force-unwraps

### DIFF
--- a/Sources/SnapAuth/SnapAuth+ASACPCP.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACPCP.swift
@@ -4,8 +4,13 @@ import AuthenticationServices
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, visionOS 1.0, *)
 extension SnapAuth: ASAuthorizationControllerPresentationContextProviding {
     public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
-        // FIXME: do not force unwrap
-        logger.debug("presentation anchor")
+        guard anchor != nil else {
+            // There's currently no logical path here since the three
+            // entrypoints all set the anchor, but in case more direct control
+            // paths are exposed this should prevent an unwrapping crash
+            logger.error("Presentation anchor missing, providing default")
+            return ASPresentationAnchor.default
+        }
         return anchor!
     }
 }

--- a/Sources/SnapAuth/SnapAuth+BuildRequests.swift
+++ b/Sources/SnapAuth/SnapAuth+BuildRequests.swift
@@ -67,7 +67,8 @@ extension SnapAuth {
         }
 
 #if HARDWARE_KEY_SUPPORT
-        if authenticators.contains(.securityKey) {
+        if authenticators.contains(.securityKey) &&
+           options.publicKey.allowCredentials != nil {
 
             let provider = ASAuthorizationSecurityKeyPublicKeyCredentialProvider(
                 relyingPartyIdentifier: options.publicKey.rpId)


### PR DESCRIPTION
Force-unwraps can lead to runtime crashes if the underlying value is `nil`. I went through and searched for every `!` in the codebase. Most already had a guard of some kind (some a literal `guard`, others with some other conditional). This adds some checks for the last ones:

- buildAuthRequests is not useful without allowCredentials in the hardware key path, so that path is skipped if no allowCredential is provided (the API will always provide them when a username or id is sent, so this is more of a typechecking formality)
- the ASPresentationAnchor needs to be set for the UI to load, so an additional fallback was put in place in case the internal value is nil


Fixes #9