### PR TITLE
Update internals to use new routes

### DIFF
--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -103,7 +103,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
 
         Task {
             let response = await api.makeRequest(
-                path: "/registration/process",
+                path: "/attestation/process",
                 body: body,
                 type: SAProcessAuthResponse.self) // TODO: rename this type
             guard case let .success(processAuth) = response else {
@@ -149,7 +149,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
 //        logger.debug("user id \(assertion.userID.base64EncodedString())")
         Task {
             let response = await api.makeRequest(
-                path: "/auth/process",
+                path: "/assertion/process",
                 body: body,
                 type: SAProcessAuthResponse.self)
             guard case let .success(authResponse) = response else {

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -39,7 +39,7 @@ extension SnapAuth {
         autoFillDelegate = delegate
         Task {
             let response = await api.makeRequest(
-                path: "/auth/createOptions",
+                path: "/assertion/options",
                 body: [:] as [String:String],
                 type: SACreateAuthOptionsResponse.self)
 

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -124,7 +124,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
 
         let body = SACreateRegisterOptionsRequest(user: nil)
         let response = await api.makeRequest(
-            path: "/registration/createOptions",
+            path: "/attestation/options",
             body: body,
             type: SACreateRegisterOptionsResponse.self)
 
@@ -198,7 +198,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         let body = ["user": user]
 
         let response = await api.makeRequest(
-            path: "/auth/createOptions",
+            path: "/assertion/options",
             body: body,
             type: SACreateAuthOptionsResponse.self)
 


### PR DESCRIPTION
The preferred routes for the client APIs have been updated prior to 1.0 SDKs shipping.