### PR TITLE
Rework autofill to also use async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,42 @@ struct SignInView: View {
 }
 ```
 
+### Autofill-assisted Requests
+
+To have the system suggest a passkey when a username field is focused, there ar
+
+1. Add `.textContentType(.username)` to the username `TextField`, if not already set:
+
+```swift
+TextField("Username", text: $userName)
+  .textContentType(.username)
+```
+
+2. Run the autofill API when the view is presented:
+
+```swift
+// ...
+var body: some View {
+  VStack {
+    // ...
+  }
+  .onAppear(perform: autofill) // <-- Add this
+}
+
+// And this
+func autofill() {
+  Task {
+    let autofillResult = await snapAuth.handleAutofill()
+    guard case .success(let auth) = autofillResult else {
+      // Autofill failed, this is common and generally safe to ignore
+      return
+    }
+    // Send auth.token to your backend to sign in the user, as above
+  }
+}
+```
+
+
 ## Known issues
 
 In our testing, the sign in dialog in tvOS doesn't open, at least in the simulator.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ func autofill() {
 In our testing, the sign in dialog in tvOS doesn't open, at least in the simulator.
 
 Even with the Apple-documented configuration, the AutoFill API does not reliably provide passkey suggestions.
+There appears to be a display issue inside the SwiftUI and UIKit internals causing the suggestion bar to not render consistently.
+We have filed a Feedback with Apple, but this is outside of our control.
 
 ## Useful resources
 

--- a/README.md
+++ b/README.md
@@ -110,13 +110,13 @@ struct SignInView: View {
 
 ### Autofill-assisted Requests
 
-To have the system suggest a passkey when a username field is focused, there ar
+To have the system suggest a passkey when a username field is focused, make the following additions to start the process and handle the result:
 
 1. Add `.textContentType(.username)` to the username `TextField`, if not already set:
 
 ```swift
 TextField("Username", text: $userName)
-  .textContentType(.username)
+  .textContentType(.username) // <-- Add this
 ```
 
 2. Run the autofill API when the view is presented:

--- a/README.md
+++ b/README.md
@@ -110,6 +110,11 @@ struct SignInView: View {
 
 ### Autofill-assisted Requests
 
+> [!NOTE]
+> Autofill is (at present) only supported on iOS/iPadOS >= 16 and visionOS.
+> On other platforms or OS versions, this will immediately return a failure code
+> indicating a lack of platform support.
+
 To have the system suggest a passkey when a username field is focused, make the following additions to start the process and handle the result:
 
 1. Add `.textContentType(.username)` to the username `TextField`, if not already set:
@@ -142,7 +147,6 @@ func autofill() {
   }
 }
 ```
-
 
 ## Known issues
 

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -5,6 +5,9 @@ public enum SnapAuthError: Error {
     /// A new request is starting, so the one in flight was canceled
     case newRequestStarting
 
+    /// This needs APIs that are not supported on the current platform
+    case unsupportedOnPlatform
+
     // MARK: Internal errors, which could represent SnapAuth bugs
 
     /// The SDK received a response from SnapAuth, but it arrived in an

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -54,11 +54,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
     /// Sends the error to the appropriate delegate method and resets the internal state back to idle
     private func sendError(_ error: SnapAuthError) {
         // One or the other should eb set, but not both
-        assert(
-            (continuation != nil && autoFillDelegate == nil)
-            || (continuation == nil && autoFillDelegate != nil)
-        )
-        autoFillDelegate = nil
+        assert(continuation != nil)
         continuation?.resume(returning: .failure(error))
         continuation = nil
     }
@@ -160,13 +156,6 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
             let rewrapped = SnapAuthTokenInfo(
                 token: authResponse.token,
                 expiresAt: authResponse.expiresAt)
-
-            // Short-term BC hack
-            if autoFillDelegate != nil {
-                autoFillDelegate!.snapAuth(didAutoFillWithResult: .success(rewrapped))
-                autoFillDelegate = nil
-                return
-            }
 
             assert(continuation != nil)
             continuation?.resume(returning: .success(rewrapped))

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -10,6 +10,10 @@ import AuthenticationServices
 extension SnapAuth {
 
     /// Starts the AutoFill process using a default ASPresentationAnchor
+    ///
+    /// This uses APIs that are unavailable prior to iOS 16, and will
+    /// immediately return an .unsupportedOnPlatform error code on devices where
+    /// it cannot run.
     public func handleAutoFill() async -> SnapAuthResult {
         await handleAutoFill(anchor: .default)
     }

--- a/Sources/SnapAuth/SnapAuth+AutoFill.swift
+++ b/Sources/SnapAuth/SnapAuth+AutoFill.swift
@@ -10,53 +10,54 @@ import AuthenticationServices
 extension SnapAuth {
 
     /// Starts the AutoFill process using a default ASPresentationAnchor
-    @available(iOS 16.0, *)
-    public func handleAutoFill(delegate: SnapAuthAutoFillDelegate) {
-        handleAutoFill(delegate: delegate, anchor: .default)
+    public func handleAutoFill() async -> SnapAuthResult {
+        await handleAutoFill(anchor: .default)
     }
 
     /// Use the specified anchor.
     /// This may be exposed publiy if needed, but the intent/goal is the default is (almost) always correct
-    @available(iOS 16.0, *)
     internal func handleAutoFill(
-        delegate: SnapAuthAutoFillDelegate,
         anchor: ASPresentationAnchor
-    ) {
+    ) async -> SnapAuthResult {
         self.anchor = anchor
 
-        handleAutoFill(delegate: delegate, presentationContextProvider: self)
+        return await handleAutoFill(presentationContextProvider: self)
     }
 
     /// Use the specified presentationContextProvider.
     /// Like with handleAutoFill(anchor:) this could get publicly exposed later but is for the "file a bug" case
-    @available(iOS 16.0, *)
     internal func handleAutoFill(
-        delegate: SnapAuthAutoFillDelegate,
         presentationContextProvider: ASAuthorizationControllerPresentationContextProviding
-    ) {
+    ) async -> SnapAuthResult {
         reset()
-        autoFillDelegate = delegate
-        Task {
-            let response = await api.makeRequest(
-                path: "/assertion/options",
-                body: [:] as [String:String],
-                type: SACreateAuthOptionsResponse.self)
+        // TODO: filter other unsupported platforms (do this better than the top-level ifdef)
+        guard #available(iOS 16, *) else {
+            return .failure(.unsupportedOnPlatform)
+        }
 
-            guard case let .success(options) = response else {
-                // TODO: decide how to handle AutoFill errors
-                return
-            }
+        let response = await self.api.makeRequest(
+            path: "/assertion/options",
+            body: [:] as [String:String],
+            type: SACreateAuthOptionsResponse.self)
 
-            // AutoFill always only uses passkeys, so this is not configurable
-            let authRequests = buildAuthRequests(
-                from: options,
-                authenticators: [.passkey])
+        guard case let .success(options) = response else {
+            // TODO: decide how to handle AutoFill errors
+            return .failure(response.getError()!)
+        }
 
-            let controller = ASAuthorizationController(authorizationRequests: authRequests)
-            authController = controller
-            controller.delegate = self
-            controller.presentationContextProvider = presentationContextProvider
-            logger.debug("AF perform")
+        // AutoFill always only uses passkeys, so this is not configurable
+        let authRequests = self.buildAuthRequests(
+            from: options,
+            authenticators: [.passkey])
+
+        let controller = ASAuthorizationController(authorizationRequests: authRequests)
+        authController = controller
+        controller.delegate = self
+        controller.presentationContextProvider = presentationContextProvider
+        logger.debug("AF perform")
+        return await withCheckedContinuation { continuation in
+            assert(self.continuation == nil)
+            self.continuation = continuation // as! CheckedContinuation<SnapAuthResult, Never>
             controller.performAutoFillAssistedRequests()
         }
     }

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -9,9 +9,6 @@ import os
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
 public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
 
-    /// The delegate that SnapAuth informs about the success or failure of an AutoFill operation.
-    internal var autoFillDelegate: SnapAuthAutoFillDelegate?
-
     internal let api: SnapAuthClient
 
     internal let logger: Logger

--- a/Sources/SnapAuth/SnapAuthDelegate.swift
+++ b/Sources/SnapAuth/SnapAuthDelegate.swift
@@ -1,10 +1,5 @@
 import Foundation
 
-/// An interface for providing information about the outcome of a SnapAuth AutoFill request
-public protocol SnapAuthAutoFillDelegate {
-    func snapAuth(didAutoFillWithResult result: SnapAuthResult)
-}
-
 public struct SnapAuthTokenInfo {
     /// The registration or authentication token.
     ///


### PR DESCRIPTION
As noted in #29, the initial design of the autofill interactions used a delegate-based system, rather than async/await like the modal APIs. This was based on an incorrect assumption (carried over from web, where it may also be flawed) on how promises resolve. Upon further experimentation, it seems perfectly fine and non-problematic to have a promise that might take minutes to resolve and not have it block other interactions.

This (breaking) change adjusts the autofill API to also use async/await instead of delegates. Client code is a lot more straightforward, and the internals become more reliable since a bunch of conditional paths are eliminated.

In the same vein, I've also added a new `.unsupportedOnPlatform` error code so that clients can have fewer availability checks, part of #30. The API as a whole is still `#if`'d to iOS+visionOS, but that will get lifted eventually in a separate PR (see #16).