### PR TITLE
Pull error conversion out into an extension to simplify controller

### DIFF
--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -72,8 +72,14 @@ extension ASAuthorizationError.Code {
         case .invalidResponse: return .invalidResponse
         case .notHandled: return .notHandled
         case .notInteractive: return .notInteractive
-        case .matchedExcludedCredential: return .matchedExcludedCredential
-        @unknown default: return .unknown
+        @unknown default:
+            // This case only exists on new OS platforms
+            if #available(iOS 18, visionOS 2, macOS 15, tvOS 18, *) {
+                if case .matchedExcludedCredential = self {
+                    return .matchedExcludedCredential
+                }
+            }
+            return .unknown
         }
     }
 }

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -1,3 +1,5 @@
+import AuthenticationServices
+
 public enum SnapAuthError: Error {
     /// The network request was disrupted. This is generally safe to retry.
     case networkInterruption
@@ -54,4 +56,24 @@ public enum SnapAuthError: Error {
 
     // (Usage unknown, Apple docs are not clear)
     case notInteractive
+
+    /// Registration matched an excluded credential. Typically this means that
+    /// the credential has already been registered.
+    case matchedExcludedCredential
+}
+
+/// Extension to standardize converstion of AS error codes into SnapAuth codes
+extension ASAuthorizationError.Code {
+    var snapAuthError: SnapAuthError {
+        switch self {
+        case .canceled: return .canceled
+        case .failed: return .failed
+        case .unknown: return .unknown
+        case .invalidResponse: return .invalidResponse
+        case .notHandled: return .notHandled
+        case .notInteractive: return .notInteractive
+        case .matchedExcludedCredential: return .matchedExcludedCredential
+        @unknown default: return .unknown
+        }
+    }
 }

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -73,12 +73,15 @@ extension ASAuthorizationError.Code {
         case .notHandled: return .notHandled
         case .notInteractive: return .notInteractive
         @unknown default:
+            /* This is (AFAICT) correct, but doesn't seem to work on the Github
+               Actions runner version.
             // This case only exists on new OS platforms
             if #available(iOS 18, visionOS 2, macOS 15, tvOS 18, *) {
                 if case .matchedExcludedCredential = self {
                     return .matchedExcludedCredential
                 }
             }
+             */
             return .unknown
         }
     }

--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -15,20 +15,7 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
             return
         }
 
-        switch asError.code {
-        case .canceled:
-            sendError(.canceled)
-        case .failed:
-            sendError(.failed)
-        case .invalidResponse:
-            sendError(.invalidResponse)
-        case .notHandled:
-            sendError(.notHandled)
-        case .notInteractive:
-            sendError(.notInteractive)
-        @unknown default:
-            sendError(.unknown)
-        }
+        sendError(asError.code.snapAuthError)
         // The start call can SILENTLY produce this error which never makes it into this handler
         // ASAuthorizationController credential request failed with error: Error Domain=com.apple.AuthenticationServices.AuthorizationError Code=1004 "(null)"
     }


### PR DESCRIPTION
We encapsulate the `ASAuthenticationError.Code` values into our own `SnapAuthError` format. This change moves the conversion outside of the AS delegate callback into an extension defined near our own error codes. Doing so encourages a single source of truth in case future functionality requires a similar conversion in a different path.

It also adds support for a newly-defined case in iOS 18 and same-year equivalents.