### PR TITLE
Swift 6 Support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.10
+// swift-tools-version: 6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,8 @@ let package = Package(
         .target(
             name: "SnapAuth",
             swiftSettings: [
-                .define("HARDWARE_KEY_SUPPORT", .when(platforms: [.iOS, .macOS]))
+                .define("HARDWARE_KEY_SUPPORT", .when(platforms: [.iOS, .macOS])),
+                .swiftLanguageVersion(.v6),
             ]),
         .testTarget(
             name: "SnapAuthTests",

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -1,3 +1,5 @@
+import AuthenticationServices
+
 public enum SnapAuthError: Error {
     /// The network request was disrupted. This is generally safe to retry.
     case networkInterruption
@@ -54,4 +56,24 @@ public enum SnapAuthError: Error {
 
     // (Usage unknown, Apple docs are not clear)
     case notInteractive
+
+    /// Registration matched an excluded credential. Typically this means that
+    /// the credential has already been registered.
+    case matchedExcludedCredential
+}
+
+/// Extension to standardize converstion of AS error codes into SnapAuth codes
+extension ASAuthorizationError.Code {
+    var snapAuthError: SnapAuthError {
+        switch self {
+        case .canceled: return .canceled
+        case .failed: return .failed
+        case .unknown: return .unknown
+        case .invalidResponse: return .invalidResponse
+        case .notHandled: return .notHandled
+        case .notInteractive: return .notInteractive
+        case .matchedExcludedCredential: return .matchedExcludedCredential
+        @unknown default: return .unknown
+        }
+    }
 }

--- a/Sources/SnapAuth/Errors.swift
+++ b/Sources/SnapAuth/Errors.swift
@@ -72,16 +72,13 @@ extension ASAuthorizationError.Code {
         case .invalidResponse: return .invalidResponse
         case .notHandled: return .notHandled
         case .notInteractive: return .notInteractive
-        @unknown default:
-            /* This is (AFAICT) correct, but doesn't seem to work on the Github
-               Actions runner version.
+        default:
             // This case only exists on new OS platforms
             if #available(iOS 18, visionOS 2, macOS 15, tvOS 18, *) {
                 if case .matchedExcludedCredential = self {
                     return .matchedExcludedCredential
                 }
             }
-             */
             return .unknown
         }
     }

--- a/Sources/SnapAuth/PresentationAnchor.swift
+++ b/Sources/SnapAuth/PresentationAnchor.swift
@@ -1,14 +1,20 @@
 import AuthenticationServices
 
-#if os(macOS)
-// FIXME: Figure out better fallback mechanisms here.
-// This will cause a new window to open _and remain open_
-fileprivate let defaultPresentationAnchor: ASPresentationAnchor = NSApplication.shared.mainWindow ?? ASPresentationAnchor()
-#else
-fileprivate let defaultPresentationAnchor: ASPresentationAnchor = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController?.view.window ?? ASPresentationAnchor()
-#endif
-
 extension ASPresentationAnchor {
     /// A platform-specific anchor, intended to be used by ASAuthorizationController
-    static let `default` = defaultPresentationAnchor
+    static var `default`: ASPresentationAnchor {
+#if os(macOS)
+        // FIXME: Figure out better fallback mechanisms here.
+        // This will cause a new window to open _and remain open_
+        return NSApplication.shared.mainWindow ?? ASPresentationAnchor()
+#else
+        return (UIApplication.shared.connectedScenes.first as? UIWindowScene)?
+            .windows
+            .first?
+            .rootViewController?
+            .view
+            .window
+        ?? ASPresentationAnchor()
+#endif
+    }
 }

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -7,6 +7,7 @@ import os
 /// This is used to start the passkey registration and authentication processes,
 /// typically in the `action` of a `Button`
 @available(macOS 12.0, iOS 15.0, tvOS 16.0, *)
+@MainActor
 public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDelegate
 
     internal let api: SnapAuthClient
@@ -223,7 +224,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 }
 
-public enum AuthenticatingUser {
+public enum AuthenticatingUser: Sendable {
     /// Your application's internal identifier for the user (usually a primary key)
     case id(String)
     /// The user's handle, such as a username or email address

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -44,7 +44,7 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
     }
 
     /// Permitted authenticator types
-    public enum Authenticator: CaseIterable {
+    public enum Authenticator: CaseIterable, Sendable {
         /// Allow all available authenticator types to be used
         public static let all = Set(Authenticator.allCases)
 


### PR DESCRIPTION
Adopts Swift 6 and its data race safety features. This should be a non-breaking change in terms of code (it didn't require changes to the sample app used to test the SDK), but does seem to require being on the latest XCode beta which could trigger some workflow breakage. I'm not sure the best way to handle that in terms of versioning, but in any case I'm temporarily blocked by the supported CI actions.

To make this work, the following changes were adopted:
- `@MainActor` added to the SDK
- `Sendable` added to a couple data structures
- `ASPresentationAnchor.default` extension reworked as a computed property instead of a `fileprivate let`
- The ASAuthorizationControllerDelegate methods are marked `nonisolated` (required for protocol compliance), and some of their internals are wrapped in `Task { @MainActor in ... }` to get back to the right actor.

I tried a couple other approaches that felt like they'd be less likely to hog resources on the main thread (generally, trying to make `SnapAuth` conform to `Sendable` or turn into an `Actor`) that clearly weren't going anywhere without pretty substantial refactoring. I won't pretend to be a Swift expert; if someone who is chimes in with a better way, this can be revisited.

Posting as-is for review, but the CI tooling will need some updates before this will build and can be landed. I expect this will solidify closer to the fall OS releases.

Fixes #26 