### PR TITLE
Remove erroneous assertion

### DIFF
--- a/Sources/SnapAuth/SnapAuth+ASACD.swift
+++ b/Sources/SnapAuth/SnapAuth+ASACD.swift
@@ -40,8 +40,6 @@ extension SnapAuth: ASAuthorizationControllerDelegate {
 
     /// Sends the error to the appropriate delegate method and resets the internal state back to idle
     private func sendError(_ error: SnapAuthError) {
-        // One or the other should eb set, but not both
-        assert(continuation != nil)
         continuation?.resume(returning: .failure(error))
         continuation = nil
     }


### PR DESCRIPTION
#31 adjusted the assertion during sending errors back, and reintroduced the data race from canceling the autofill request due to starting a modal one (explicitly returning a failure to the continuation, clearing it out, and canceling the authController - which went back to sendError)

This removes the assertion, since it was logically unsound, not to mention unhelpful. I've done another bunch of manual testing in a sample app and can no longer reproduce the issue. I'm not sure how to cover this in automated tests to prevent another regression, but I'll file a ticket in case someone finds a way.