### PR TITLE
Add availability APIs

### DIFF
--- a/Sources/SnapAuth/Availability.swift
+++ b/Sources/SnapAuth/Availability.swift
@@ -1,0 +1,33 @@
+/// Platform availability hints for passkeys and hardware authenticators
+struct SAAvailability {
+
+    /// Indicates whether passkey autofill requests are supported on the current
+    /// platform/device.
+    static var autofill: Bool {
+#if (os(iOS) || os(visionOS))
+        return #available(iOS 16, visionOS 1, *)
+#else
+        return false
+#endif
+    }
+
+    /// Indicates whether external security keys are supported on the current
+    /// platform/device.
+    static var securityKeys: Bool {
+#if HARDWARE_KEY_SUPPORT
+        return true
+#else
+        return false
+#endif
+    }
+
+    /// Indicates whether automatic passkey upgrades are supported on the
+    /// current platform/device.
+    static var passkeyUpgrades: Bool {
+#if (os(iOS) || os(macOS) || os(visionOS))
+        return #available(iOS 18, macOS 15, visionOS 2, *)
+#else
+        return false
+#endif
+    }
+}

--- a/Sources/SnapAuth/Availability.swift
+++ b/Sources/SnapAuth/Availability.swift
@@ -5,10 +5,11 @@ struct SAAvailability {
     /// platform/device.
     static var autofill: Bool {
 #if (os(iOS) || os(visionOS))
-        return #available(iOS 16, visionOS 1, *)
-#else
-        return false
+        if #available(iOS 16, visionOS 1, *) {
+            return true
+        }
 #endif
+        return false
     }
 
     /// Indicates whether external security keys are supported on the current
@@ -25,9 +26,10 @@ struct SAAvailability {
     /// current platform/device.
     static var passkeyUpgrades: Bool {
 #if (os(iOS) || os(macOS) || os(visionOS))
-        return #available(iOS 18, macOS 15, visionOS 2, *)
-#else
-        return false
+        if #available(iOS 18, macOS 15, visionOS 2, *) {
+            return true
+        }
 #endif
+        return false
     }
 }


### PR DESCRIPTION
This adds some centralized hints for platform availability, which should make addressing #30 easier and clearer.

For now this is being kept internal, but it's intended to become public in short order.