### PR TITLE
Automatic passkey upgrade support

### DIFF
--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -16,6 +16,7 @@ struct SAWrappedResponse<T>: Decodable where T: Decodable {
 
 struct SACreateRegisterOptionsRequest: Encodable {
     let user: AuthenticatingUser?
+    let upgrade: Bool
 }
 struct SACreateRegisterOptionsResponse: Decodable {
     let publicKey: PublicKeyOptions

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -94,7 +94,7 @@ enum Transport: String, Encodable {
 
 struct SACreateAuthOptionsResponse: Decodable {
     let publicKey: PublicKeyOptions
-    // mediation
+    let mediation: CredentialMediationRequirement
 
     struct PublicKeyOptions: Decodable {
 
@@ -131,4 +131,16 @@ struct SAProcessAuthRequest: Encodable {
 struct SAProcessAuthResponse: Decodable {
     let token: String
     let expiresAt: Date
+}
+
+/// https://www.w3.org/TR/credential-management-1/#mediation-requirements
+enum CredentialMediationRequirement: String, Decodable {
+    /// Default behavior: present requests in foreground if needed.
+    case optional = "optional"
+    /// Used to indicate operation should be done in the background.
+    case conditional = "conditional"
+    /// Fail if operation cannot be performed without user involvement. Unused; only present for future-proofing.
+    case silent = "silent"
+    /// Fail if operation cannot be performed with user involvement. Unused; only present for future-proofing.
+    case required = "required"
 }

--- a/Sources/SnapAuth/API.swift
+++ b/Sources/SnapAuth/API.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AuthenticationServices
 
 /// Wrapper that matches the API wire format
 ///
@@ -20,6 +21,7 @@ struct SACreateRegisterOptionsRequest: Encodable {
 }
 struct SACreateRegisterOptionsResponse: Decodable {
     let publicKey: PublicKeyOptions
+    let mediation: CredentialMediationRequirement
 
     struct PublicKeyOptions: Decodable {
         let rp: RPInfo
@@ -143,4 +145,12 @@ enum CredentialMediationRequirement: String, Decodable {
     case silent = "silent"
     /// Fail if operation cannot be performed with user involvement. Unused; only present for future-proofing.
     case required = "required"
+
+    @available(iOS 18, visionOS 2.0, macOS 15.0, *)
+    var requestStyle: ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest.RequestStyle {
+        if (self == .conditional) {
+            return .conditional
+        }
+        return .standard
+    }
 }

--- a/Sources/SnapAuth/Availability.swift
+++ b/Sources/SnapAuth/Availability.swift
@@ -1,0 +1,33 @@
+/// Platform availability hints for passkeys and hardware authenticators
+struct SAAvailability {
+
+    /// Indicates whether passkey autofill requests are supported on the current
+    /// platform/device.
+    static var autofill: Bool {
+#if (os(iOS) || os(visionOS))
+        return #available(iOS 16, visionOS 1, *)
+#else
+        return false
+#endif
+    }
+
+    /// Indicates whether external security keys are supported on the current
+    /// platform/device.
+    static var securityKeys: Bool {
+#if HARDWARE_KEY_SUPPORT
+        return true
+#else
+        return false
+#endif
+    }
+
+    /// Indicates whether automatic passkey upgrades are supported on the
+    /// current platform/device.
+    static var passkeyUpgrades: Bool {
+#if (os(iOS) || os(macOS) || os(visionOS))
+        return #available(iOS 18, macOS 15, visionOS 2, *)
+#else
+        return false
+#endif
+    }
+}

--- a/Sources/SnapAuth/Availability.swift
+++ b/Sources/SnapAuth/Availability.swift
@@ -5,10 +5,11 @@ struct SAAvailability {
     /// platform/device.
     static var autofill: Bool {
 #if (os(iOS) || os(visionOS))
-        return #available(iOS 16, visionOS 1, *)
-#else
-        return false
+        if #available(iOS 16, visionOS 1, *) {
+            return true
+        }
 #endif
+        return false
     }
 
     /// Indicates whether external security keys are supported on the current
@@ -25,9 +26,10 @@ struct SAAvailability {
     /// current platform/device.
     static var passkeyUpgrades: Bool {
 #if (os(iOS) || os(macOS) || os(visionOS))
-        return #available(iOS 18, macOS 15, visionOS 2, *)
-#else
-        return false
+        if #available(iOS 18, macOS 15, visionOS 2, *) {
+            return true
+        }
 #endif
+        return false
     }
 }

--- a/Sources/SnapAuth/SnapAuth+Upgrades.swift
+++ b/Sources/SnapAuth/SnapAuth+Upgrades.swift
@@ -17,7 +17,7 @@ extension SnapAuth {
             name: username,
             anchor: .default,
             displayName: displayName,
-            authenticators: Authenticator.all,
+            authenticators: [.passkey],
             upgrade: true
         )
     }

--- a/Sources/SnapAuth/SnapAuth+Upgrades.swift
+++ b/Sources/SnapAuth/SnapAuth+Upgrades.swift
@@ -12,8 +12,11 @@ extension SnapAuth {
         username: String,
         displayName: String? = nil
     ) async -> SnapAuthResult {
+        if !SAAvailability.passkeyUpgrades {
+            return .failure(.unsupportedOnPlatform)
+        }
 
-        await startRegister(
+        return await startRegister(
             name: username,
             anchor: .default,
             displayName: displayName,

--- a/Sources/SnapAuth/SnapAuth+Upgrades.swift
+++ b/Sources/SnapAuth/SnapAuth+Upgrades.swift
@@ -1,0 +1,24 @@
+extension SnapAuth {
+    /// Attempts to upgrade an existing account to use passkeys by creating one
+    /// in the background.
+    ///
+    /// This should be called after a user signs in. Errors should not be
+    /// displayed to the user, though may be logged.
+    ///
+    /// - Parameters:
+    ///   - name: The name of the user. This should be a username or handle.
+    ///   - displayName: The proper name of the user. If omitted, name will be used.
+    public func upgradeToPasskey(
+        username: String,
+        displayName: String? = nil
+    ) async -> SnapAuthResult {
+
+        await startRegister(
+            name: username,
+            anchor: .default,
+            displayName: displayName,
+            authenticators: Authenticator.all,
+            upgrade: true
+        )
+    }
+}

--- a/Sources/SnapAuth/SnapAuth+Upgrades.swift
+++ b/Sources/SnapAuth/SnapAuth+Upgrades.swift
@@ -6,7 +6,7 @@ extension SnapAuth {
     /// displayed to the user, though may be logged.
     ///
     /// - Parameters:
-    ///   - name: The name of the user. This should be a username or handle.
+    ///   - username: The username of the user, such as an email address or handle
     ///   - displayName: The proper name of the user. If omitted, name will be used.
     public func upgradeToPasskey(
         username: String,
@@ -17,7 +17,7 @@ extension SnapAuth {
         }
 
         return await startRegister(
-            name: username,
+            username: username,
             anchor: .default,
             displayName: displayName,
             authenticators: [.passkey],

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -114,12 +114,13 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
         name: String,
         anchor: ASPresentationAnchor,
         displayName: String? = nil,
-        authenticators: Set<Authenticator> = Authenticator.all
+        authenticators: Set<Authenticator> = Authenticator.all,
+        upgrade: Bool
     ) async -> SnapAuthResult {
         reset()
         self.anchor = anchor
 
-        let body = SACreateRegisterOptionsRequest(user: nil)
+        let body = SACreateRegisterOptionsRequest(user: nil, upgrade: upgrade)
         let response = await api.makeRequest(
             path: "/attestation/options",
             body: body,

--- a/Sources/SnapAuth/SnapAuth.swift
+++ b/Sources/SnapAuth/SnapAuth.swift
@@ -106,7 +106,8 @@ public class SnapAuth: NSObject { // NSObject for ASAuthorizationControllerDeleg
             name: name,
             anchor: .default,
             displayName: displayName,
-            authenticators: authenticators)
+            authenticators: authenticators,
+            upgrade: false)
     }
 
     // TODO: Only make this public if needed?


### PR DESCRIPTION
This adds a new core SDK method, `upgradeToPasskey(name: String, displayName: String?)`, which attempts a background upgrade of a password-based account to a passkey. On unsupported platforms, it will return a `.failure(.unsupportedOnPlatform)` - so there's no need to run your own availability checks.

Fixes #27 

TODO:
- Improve docs
- Link to WWDC video in readme
- Add extra safeguards to ensure this can't trigger a modal registration
- Misc. cleanup